### PR TITLE
Adding IComparable to concepts

### DIFF
--- a/Source/Concepts/ConceptAs.cs
+++ b/Source/Concepts/ConceptAs.cs
@@ -79,6 +79,16 @@ namespace Dolittle.Concepts
             return a.CompareTo(b) == -1;
         }
 
+        public static bool operator >=(ConceptAs<T> a, ConceptAs<T> b)
+        {
+            return a.CompareTo(b) > -1;
+        }
+
+        public static bool operator <= (ConceptAs<T> a, ConceptAs<T> b)
+        {
+            return a.CompareTo(b) < 1;
+        }
+        
         public override int GetHashCode()
         {
             return HashCodeHelper.Generate(typeof (T), Value);

--- a/Source/Concepts/ConceptAs.cs
+++ b/Source/Concepts/ConceptAs.cs
@@ -69,6 +69,16 @@ namespace Dolittle.Concepts
             return !(a == b);
         }
 
+        public static bool operator > (ConceptAs<T> a, ConceptAs<T> b)
+        {
+            return a.CompareTo(b) == 1;
+        }
+
+        public static bool operator < (ConceptAs<T> a, ConceptAs<T> b)
+        {
+            return a.CompareTo(b) == -1;
+        }
+
         public override int GetHashCode()
         {
             return HashCodeHelper.Generate(typeof (T), Value);

--- a/Source/Concepts/ConceptAs.cs
+++ b/Source/Concepts/ConceptAs.cs
@@ -11,7 +11,7 @@ namespace Dolittle.Concepts
     /// Expresses a Concept as a another type, usually a primitive such as Guid, Int or String
     /// </summary>
     /// <typeparam name="T"></typeparam>
-    public class ConceptAs<T> : IEquatable<ConceptAs<T>>
+    public class ConceptAs<T> : IEquatable<ConceptAs<T>>, IComparable<ConceptAs<T>>, IComparable
     {
         /// <summary>
         /// The underlying primitive value of this concept
@@ -85,6 +85,20 @@ namespace Dolittle.Concepts
                 return value == string.Empty;
 
             return Value.Equals(default(T));
+        }
+
+        public virtual int CompareTo(ConceptAs<T> other)
+        {
+            if(other == null)
+                return 1;
+
+            return Comparer<T>.Default.Compare(this.Value,other.Value);
+        }
+
+        public virtual int CompareTo(object obj)
+        {
+            var other = obj as ConceptAs<T>;
+            return CompareTo(other);
         }
 #pragma warning restore 1591 // Xml Comments
     }

--- a/Specifications/Concepts/for_ConceptAs/given/comparable_concepts.cs
+++ b/Specifications/Concepts/for_ConceptAs/given/comparable_concepts.cs
@@ -2,17 +2,12 @@ using Dolittle.Specs.Concepts.given;
 
 namespace Dolittle.Specs.Concepts.for_ConceptAs.given
 {
-    public class comparable_concepts
+
+    public class comparable_concepts  : test_concepts 
     {
         public const int LESS_THAN = -1;
         public const int EQUAL = 0;
         public const int GREATER_THAN = 1;
-
-        protected static IntConcept least = 0;
-        protected static IntConcept most = 10;
-        protected static IntConcept another_instance_of_most = most.Value;
-        protected static IntConcept middle = 5;
-
         protected static int compare_least_to_most;
         protected static int compare_least_to_middle;
         protected static int compare_least_to_self;

--- a/Specifications/Concepts/for_ConceptAs/given/comparable_concepts.cs
+++ b/Specifications/Concepts/for_ConceptAs/given/comparable_concepts.cs
@@ -1,0 +1,27 @@
+using Dolittle.Specs.Concepts.given;
+
+namespace Dolittle.Specs.Concepts.for_ConceptAs.given
+{
+    public class comparable_concepts
+    {
+        public const int LESS_THAN = -1;
+        public const int EQUAL = 0;
+        public const int GREATER_THAN = 1;
+
+        protected static IntConcept least = 0;
+        protected static IntConcept most = 10;
+        protected static IntConcept another_instance_of_most = most.Value;
+        protected static IntConcept middle = 5;
+
+        protected static int compare_least_to_most;
+        protected static int compare_least_to_middle;
+        protected static int compare_least_to_self;
+        protected static int compare_middle_to_least;
+        protected static int compare_middle_to_most;
+        protected static int compare_middle_to_self; 
+        protected static int compare_most_to_least;
+        protected static int compare_most_to_middle;
+        protected static int compare_most_to_self; 
+        protected static int compare_most_to_another_instance_of_most; 
+    }
+}

--- a/Specifications/Concepts/for_ConceptAs/given/test_concepts.cs
+++ b/Specifications/Concepts/for_ConceptAs/given/test_concepts.cs
@@ -1,0 +1,12 @@
+using Dolittle.Specs.Concepts.given;
+
+namespace Dolittle.Specs.Concepts.for_ConceptAs.given
+{
+    public class test_concepts
+    {
+        protected static IntConcept least = 0;
+        protected static IntConcept most = 10;
+        protected static IntConcept another_instance_of_most = most.Value;
+        protected static IntConcept middle = 5;
+    }
+}

--- a/Specifications/Concepts/for_ConceptAs/when_checking_is_empty_on_a_null_string_concept.cs
+++ b/Specifications/Concepts/for_ConceptAs/when_checking_is_empty_on_a_null_string_concept.cs
@@ -1,10 +1,11 @@
 ﻿using Dolittle.Concepts;
 using Machine.Specifications;
+using Dolittle.Specs.Concepts.given;
 
 namespace Dolittle.Specs.Concepts.for_ConceptAs
 {
     [Subject(typeof(ConceptAs<>))]
-    public class when_checking_is_empty_on_a_null_string_concept : given.concepts
+    public class when_checking_is_empty_on_a_null_string_concept : Dolittle.Specs.Concepts.given.concepts
     {
         static bool is_empty;
 

--- a/Specifications/Concepts/for_ConceptAs/when_checking_is_empty_on_a_populated_long.cs
+++ b/Specifications/Concepts/for_ConceptAs/when_checking_is_empty_on_a_populated_long.cs
@@ -4,7 +4,7 @@ using Machine.Specifications;
 namespace Dolittle.Specs.Concepts.for_ConceptAs
 {
     [Subject(typeof(ConceptAs<>))]
-    public class when_checking_is_empty_on_a_populated_long : given.concepts
+    public class when_checking_is_empty_on_a_populated_long : Dolittle.Specs.Concepts.given.concepts
     {
         static bool is_empty;
 

--- a/Specifications/Concepts/for_ConceptAs/when_checking_is_empty_on_a_populated_string_concept.cs
+++ b/Specifications/Concepts/for_ConceptAs/when_checking_is_empty_on_a_populated_string_concept.cs
@@ -4,7 +4,7 @@ using Machine.Specifications;
 namespace Dolittle.Specs.Concepts.for_ConceptAs
 {
     [Subject(typeof(ConceptAs<>))]
-    public class when_checking_is_empty_on_a_populated_string_concept : given.concepts
+    public class when_checking_is_empty_on_a_populated_string_concept : Dolittle.Specs.Concepts.given.concepts
     {
         static bool is_empty;
 

--- a/Specifications/Concepts/for_ConceptAs/when_checking_is_empty_on_an_empty_long_concept.cs
+++ b/Specifications/Concepts/for_ConceptAs/when_checking_is_empty_on_an_empty_long_concept.cs
@@ -4,7 +4,7 @@ using Machine.Specifications;
 namespace Dolittle.Specs.Concepts.for_ConceptAs
 {
     [Subject(typeof(ConceptAs<>))]
-    public class when_checking_is_empty_on_an_empty_long_concept : given.concepts
+    public class when_checking_is_empty_on_an_empty_long_concept : Dolittle.Specs.Concepts.given.concepts
     {
         static bool is_empty;
 

--- a/Specifications/Concepts/for_ConceptAs/when_checking_is_empty_on_an_empty_string_concept.cs
+++ b/Specifications/Concepts/for_ConceptAs/when_checking_is_empty_on_an_empty_string_concept.cs
@@ -4,7 +4,7 @@ using Machine.Specifications;
 namespace Dolittle.Specs.Concepts.for_ConceptAs
 {
     [Subject(typeof(ConceptAs<>))]
-    public class when_checking_is_empty_on_an_empty_string_concept : given.concepts
+    public class when_checking_is_empty_on_an_empty_string_concept : Dolittle.Specs.Concepts.given.concepts
     {
         static bool is_empty;
 

--- a/Specifications/Concepts/for_ConceptAs/when_checking_is_greater_than.cs
+++ b/Specifications/Concepts/for_ConceptAs/when_checking_is_greater_than.cs
@@ -1,0 +1,53 @@
+using Dolittle.Concepts;
+using Machine.Specifications;
+using Dolittle.Specs.Concepts.given;
+
+namespace Dolittle.Specs.Concepts.for_ConceptAs
+{
+    [Subject(typeof(ConceptAs<>))]
+    public class when_checking_is_greater_than : given.test_concepts
+    {
+        static bool least_is_greater_than_most;
+        static bool least_is_greater_than_middle;
+        static bool least_is_greater_than_self;
+        static bool least_is_greater_than_primitive_value;
+        static bool middle_is_greater_than_least;
+        static bool middle_is_greater_than_most;
+        static bool middle_is_greater_than_self;
+        static bool middle_is_greater_than_primitive_value;
+        static bool most_is_greater_than_least;
+        static bool most_is_greater_than_middle;
+        static bool most_is_greater_than_self;
+        static bool most_is_greater_than_primitive_value;
+
+        static bool blah;
+        Because of = () =>
+        {
+            least_is_greater_than_most = least > most;
+            least_is_greater_than_middle = least > middle;
+            least_is_greater_than_self = least > least;
+            least_is_greater_than_primitive_value = least > least.Value;
+            middle_is_greater_than_least = middle > least;
+            middle_is_greater_than_most = middle > most;
+            middle_is_greater_than_self = middle > middle;
+            middle_is_greater_than_primitive_value = middle > middle.Value;
+            most_is_greater_than_least = most > least;
+            most_is_greater_than_middle = most > middle;
+            most_is_greater_than_self = most > most;
+            most_is_greater_than_primitive_value = most > most.Value;
+        };
+
+        It determines_least_is_not_greater_than_most = () =>  least_is_greater_than_most.ShouldBeFalse();
+        It determines_least_is_not_greater_than_middle = () =>  least_is_greater_than_middle.ShouldBeFalse();
+        It determines_least_is_not_greater_than_self = () =>  least_is_greater_than_self.ShouldBeFalse();
+        It determines_least_is_not_greater_than_primitive_value = () =>  least_is_greater_than_primitive_value.ShouldBeFalse();
+        It determines_middle_is_not_greater_than_most = () =>  middle_is_greater_than_most.ShouldBeFalse();
+        It determines_middle_is_greater_than_least = () =>  middle_is_greater_than_least.ShouldBeTrue();
+        It determines_middle_is_not_greater_than_self = () =>  middle_is_greater_than_self.ShouldBeFalse(); 
+        It determines_middle_is_not_greater_than_primitive_value = () =>  middle_is_greater_than_primitive_value.ShouldBeFalse();
+        It determines_most_is_greater_than_least = () =>  most_is_greater_than_least.ShouldBeTrue();
+        It determines_most_is_greater_than_middle = () =>  most_is_greater_than_middle.ShouldBeTrue();
+        It determines_most_is_not_greater_than_self = () =>  most_is_greater_than_self.ShouldBeFalse(); 
+        It determines_most_is_not_greater_than_primitive_value = () =>  most_is_greater_than_primitive_value.ShouldBeFalse();
+    }
+}

--- a/Specifications/Concepts/for_ConceptAs/when_checking_is_greater_than_or_equal_to.cs
+++ b/Specifications/Concepts/for_ConceptAs/when_checking_is_greater_than_or_equal_to.cs
@@ -1,0 +1,53 @@
+using Dolittle.Concepts;
+using Machine.Specifications;
+using Dolittle.Specs.Concepts.given;
+
+namespace Dolittle.Specs.Concepts.for_ConceptAs
+{
+    [Subject(typeof(ConceptAs<>))]
+    public class when_checking_is_greater_than_or_equal_to : given.test_concepts
+    {
+        static bool least_is_greater_than_or_equal_to_most;
+        static bool least_is_greater_than_or_equal_to_middle;
+        static bool least_is_greater_than_or_equal_to_self;
+        static bool least_is_greater_than_or_equal_to_primitive_value;
+        static bool middle_is_greater_than_or_equal_to_least;
+        static bool middle_is_greater_than_or_equal_to_most;
+        static bool middle_is_greater_than_or_equal_to_self;
+        static bool middle_is_greater_than_or_equal_to_primitive_value;
+        static bool most_is_greater_than_or_equal_to_least;
+        static bool most_is_greater_than_or_equal_to_middle;
+        static bool most_is_greater_than_or_equal_to_self;
+        static bool most_is_greater_than_or_equal_to_primitive_value;
+
+        static bool blah;
+        Because of = () =>
+        {
+            least_is_greater_than_or_equal_to_most = least >= most;
+            least_is_greater_than_or_equal_to_middle = least >= middle;
+            least_is_greater_than_or_equal_to_self = least >= least;
+            least_is_greater_than_or_equal_to_primitive_value = least >= least.Value;
+            middle_is_greater_than_or_equal_to_least = middle >= least;
+            middle_is_greater_than_or_equal_to_most = middle >= most;
+            middle_is_greater_than_or_equal_to_self = middle >= middle;
+            middle_is_greater_than_or_equal_to_primitive_value = middle >= middle.Value;
+            most_is_greater_than_or_equal_to_least = most >= least;
+            most_is_greater_than_or_equal_to_middle = most >= middle;
+            most_is_greater_than_or_equal_to_self = most >= most;
+            most_is_greater_than_or_equal_to_primitive_value = most >= most.Value;
+        };
+
+        It determines_least_is_not_greater_than_or_equal_to_most = () =>  least_is_greater_than_or_equal_to_most.ShouldBeFalse();
+        It determines_least_is_not_greater_than_or_equal_to_middle = () =>  least_is_greater_than_or_equal_to_middle.ShouldBeFalse();
+        It determines_least_is_not_greater_than_or_equal_to_self = () =>  least_is_greater_than_or_equal_to_self.ShouldBeTrue();
+        It determines_least_is_not_greater_than_or_equal_to_primitive_value = () =>  least_is_greater_than_or_equal_to_primitive_value.ShouldBeTrue();
+        It determines_middle_is_not_greater_than_or_equal_to_most = () =>  middle_is_greater_than_or_equal_to_most.ShouldBeFalse();
+        It determines_middle_is_greater_than_or_equal_to_least = () =>  middle_is_greater_than_or_equal_to_least.ShouldBeTrue();
+        It determines_middle_is_not_greater_than_or_equal_to_self = () =>  middle_is_greater_than_or_equal_to_self.ShouldBeTrue(); 
+        It determines_middle_is_not_greater_than_or_equal_to_primitive_value = () =>  middle_is_greater_than_or_equal_to_primitive_value.ShouldBeTrue();
+        It determines_most_is_greater_than_or_equal_to_least = () =>  most_is_greater_than_or_equal_to_least.ShouldBeTrue();
+        It determines_most_is_greater_than_or_equal_to_middle = () =>  most_is_greater_than_or_equal_to_middle.ShouldBeTrue();
+        It determines_most_is_not_greater_than_or_equal_to_self = () =>  most_is_greater_than_or_equal_to_self.ShouldBeTrue(); 
+        It determines_most_is_not_greater_than_or_equal_to_primitive_value = () =>  most_is_greater_than_or_equal_to_primitive_value.ShouldBeTrue();
+    }
+}

--- a/Specifications/Concepts/for_ConceptAs/when_checking_is_lesser_than.cs
+++ b/Specifications/Concepts/for_ConceptAs/when_checking_is_lesser_than.cs
@@ -1,0 +1,53 @@
+﻿using Dolittle.Concepts;
+using Machine.Specifications;
+using Dolittle.Specs.Concepts.given;
+
+namespace Dolittle.Specs.Concepts.for_ConceptAs
+{
+    [Subject(typeof(ConceptAs<>))]
+    public class when_checking_is_lesser_than : given.test_concepts
+    {
+        static bool least_is_lesser_than_most;
+        static bool least_is_lesser_than_middle;
+        static bool least_is_lesser_than_self;
+        static bool least_is_lesser_than_primitive_value;
+        static bool middle_is_lesser_than_least;
+        static bool middle_is_lesser_than_most;
+        static bool middle_is_lesser_than_self;
+        static bool middle_is_lesser_than_primitive_value;
+        static bool most_is_lesser_than_least;
+        static bool most_is_lesser_than_middle;
+        static bool most_is_lesser_than_self;
+        static bool most_is_lesser_than_primitive_value;
+
+        static bool blah;
+        Because of = () =>
+        {
+            least_is_lesser_than_most = least < most;
+            least_is_lesser_than_middle = least < middle;
+            least_is_lesser_than_self = least < least;
+            least_is_lesser_than_primitive_value = least < least.Value;
+            middle_is_lesser_than_least = middle < least;
+            middle_is_lesser_than_most = middle < most;
+            middle_is_lesser_than_self = middle < middle;
+            middle_is_lesser_than_primitive_value = middle < middle.Value;
+            most_is_lesser_than_least = most < least;
+            most_is_lesser_than_middle = most < middle;
+            most_is_lesser_than_self = most < most;
+            most_is_lesser_than_primitive_value = most < most.Value;
+        };
+
+        It determines_least_is_not_lesser_than_most = () =>  least_is_lesser_than_most.ShouldBeTrue();
+        It determines_least_is_not_lesser_than_middle = () =>  least_is_lesser_than_middle.ShouldBeTrue();
+        It determines_least_is_not_lesser_than_self = () =>  least_is_lesser_than_self.ShouldBeFalse();
+        It determines_least_is_not_lesser_than_primitive_value = () =>  least_is_lesser_than_primitive_value.ShouldBeFalse();
+        It determines_middle_is_not_lesser_than_most = () =>  middle_is_lesser_than_most.ShouldBeTrue();
+        It determines_middle_is_lesser_than_least = () =>  middle_is_lesser_than_least.ShouldBeFalse();
+        It determines_middle_is_not_lesser_than_self = () =>  middle_is_lesser_than_self.ShouldBeFalse(); 
+        It determines_middle_is_not_lesser_than_primitive_value = () =>  middle_is_lesser_than_primitive_value.ShouldBeFalse();
+        It determines_most_is_lesser_than_least = () =>  most_is_lesser_than_least.ShouldBeFalse();
+        It determines_most_is_lesser_than_middle = () =>  most_is_lesser_than_middle.ShouldBeFalse();
+        It determines_most_is_not_lesser_than_self = () =>  most_is_lesser_than_self.ShouldBeFalse(); 
+        It determines_most_is_not_lesser_than_primitive_value = () =>  most_is_lesser_than_primitive_value.ShouldBeFalse();
+    }
+}

--- a/Specifications/Concepts/for_ConceptAs/when_checking_is_lesser_than_or_equal_to.cs
+++ b/Specifications/Concepts/for_ConceptAs/when_checking_is_lesser_than_or_equal_to.cs
@@ -1,0 +1,53 @@
+﻿using Dolittle.Concepts;
+using Machine.Specifications;
+using Dolittle.Specs.Concepts.given;
+
+namespace Dolittle.Specs.Concepts.for_ConceptAs
+{
+    [Subject(typeof(ConceptAs<>))]
+    public class when_checking_is_lesser_than_or_equal_to : given.test_concepts
+    {
+        static bool least_is_lesser_than_or_equal_to_most;
+        static bool least_is_lesser_than_or_equal_to_middle;
+        static bool least_is_lesser_than_or_equal_to_self;
+        static bool least_is_lesser_than_or_equal_to_primitive_value;
+        static bool middle_is_lesser_than_or_equal_to_least;
+        static bool middle_is_lesser_than_or_equal_to_most;
+        static bool middle_is_lesser_than_or_equal_to_self;
+        static bool middle_is_lesser_than_or_equal_to_primitive_value;
+        static bool most_is_lesser_than_or_equal_to_least;
+        static bool most_is_lesser_than_or_equal_to_middle;
+        static bool most_is_lesser_than_or_equal_to_self;
+        static bool most_is_lesser_than_or_equal_to_primitive_value;
+
+        static bool blah;
+        Because of = () =>
+        {
+            least_is_lesser_than_or_equal_to_most = least <= most;
+            least_is_lesser_than_or_equal_to_middle = least <= middle;
+            least_is_lesser_than_or_equal_to_self = least <= least;
+            least_is_lesser_than_or_equal_to_primitive_value = least <= least.Value;
+            middle_is_lesser_than_or_equal_to_least = middle <= least;
+            middle_is_lesser_than_or_equal_to_most = middle <= most;
+            middle_is_lesser_than_or_equal_to_self = middle <= middle;
+            middle_is_lesser_than_or_equal_to_primitive_value = middle <= middle.Value;
+            most_is_lesser_than_or_equal_to_least = most <= least;
+            most_is_lesser_than_or_equal_to_middle = most <= middle;
+            most_is_lesser_than_or_equal_to_self = most <= most;
+            most_is_lesser_than_or_equal_to_primitive_value = most <= most.Value;
+        };
+
+        It determines_least_is_not_lesser_than_or_equal_to_most = () =>  least_is_lesser_than_or_equal_to_most.ShouldBeTrue();
+        It determines_least_is_not_lesser_than_or_equal_to_middle = () =>  least_is_lesser_than_or_equal_to_middle.ShouldBeTrue();
+        It determines_least_is_not_lesser_than_or_equal_to_self = () =>  least_is_lesser_than_or_equal_to_self.ShouldBeTrue();
+        It determines_least_is_not_lesser_than_or_equal_to_primitive_value = () =>  least_is_lesser_than_or_equal_to_primitive_value.ShouldBeTrue();
+        It determines_middle_is_not_lesser_than_or_equal_to_most = () =>  middle_is_lesser_than_or_equal_to_most.ShouldBeTrue();
+        It determines_middle_is_lesser_than_or_equal_to_least = () =>  middle_is_lesser_than_or_equal_to_least.ShouldBeFalse();
+        It determines_middle_is_not_lesser_than_or_equal_to_self = () =>  middle_is_lesser_than_or_equal_to_self.ShouldBeTrue(); 
+        It determines_middle_is_not_lesser_than_or_equal_to_primitive_value = () =>  middle_is_lesser_than_or_equal_to_primitive_value.ShouldBeTrue();
+        It determines_most_is_lesser_than_or_equal_to_least = () =>  most_is_lesser_than_or_equal_to_least.ShouldBeFalse();
+        It determines_most_is_lesser_than_or_equal_to_middle = () =>  most_is_lesser_than_or_equal_to_middle.ShouldBeFalse();
+        It determines_most_is_not_lesser_than_or_equal_to_self = () =>  most_is_lesser_than_or_equal_to_self.ShouldBeTrue(); 
+        It determines_most_is_not_lesser_than_or_equal_to_primitive_value = () =>  most_is_lesser_than_or_equal_to_primitive_value.ShouldBeTrue();
+    }
+}

--- a/Specifications/Concepts/for_ConceptAs/when_checking_is_lesser_than_or_equal_to.cs
+++ b/Specifications/Concepts/for_ConceptAs/when_checking_is_lesser_than_or_equal_to.cs
@@ -45,8 +45,8 @@ namespace Dolittle.Specs.Concepts.for_ConceptAs
         It determines_middle_is_lesser_than_or_equal_to_least = () =>  middle_is_lesser_than_or_equal_to_least.ShouldBeFalse();
         It determines_middle_is_not_lesser_than_or_equal_to_self = () =>  middle_is_lesser_than_or_equal_to_self.ShouldBeTrue(); 
         It determines_middle_is_not_lesser_than_or_equal_to_primitive_value = () =>  middle_is_lesser_than_or_equal_to_primitive_value.ShouldBeTrue();
-        It determines_most_is_lesser_than_or_equal_to_least = () =>  most_is_lesser_than_or_equal_to_least.ShouldBeFalse();
-        It determines_most_is_lesser_than_or_equal_to_middle = () =>  most_is_lesser_than_or_equal_to_middle.ShouldBeFalse();
+        It determines_most_is_not_lesser_than_or_equal_to_least = () =>  most_is_lesser_than_or_equal_to_least.ShouldBeFalse();
+        It determines_most_is_not_lesser_than_or_equal_to_middle = () =>  most_is_lesser_than_or_equal_to_middle.ShouldBeFalse();
         It determines_most_is_not_lesser_than_or_equal_to_self = () =>  most_is_lesser_than_or_equal_to_self.ShouldBeTrue(); 
         It determines_most_is_not_lesser_than_or_equal_to_primitive_value = () =>  most_is_lesser_than_or_equal_to_primitive_value.ShouldBeTrue();
     }

--- a/Specifications/Concepts/for_ConceptAs/when_comparing_on_generic_method.cs
+++ b/Specifications/Concepts/for_ConceptAs/when_comparing_on_generic_method.cs
@@ -31,4 +31,36 @@ namespace Dolittle.Specs.Concepts.for_ConceptAs
         It determines_most_is_equal_to_itself = () => compare_most_to_self.ShouldEqual(given.comparable_concepts.EQUAL);
         It determines_most_is_equal_to_another_instance_of_most = () => compare_most_to_another_instance_of_most.ShouldEqual(given.comparable_concepts.EQUAL);
     }
+
+    [Subject(typeof(ConceptAs<>))]
+    public class when_comparing_on_non_generic_method : given.comparable_concepts
+    {
+        static int compare_least_to_object_of_another_type;
+        Because of = () =>
+        {
+            compare_least_to_most = least.CompareTo((object)most);
+            compare_least_to_middle = least.CompareTo((object)middle);
+            compare_least_to_self = least.CompareTo((object)least);
+            compare_middle_to_least = middle.CompareTo((object)least);
+            compare_middle_to_most = middle.CompareTo((object)most);
+            compare_middle_to_self = middle.CompareTo((object)middle);
+            compare_most_to_least = most.CompareTo((object)least);
+            compare_most_to_middle = most.CompareTo((object)middle);
+            compare_most_to_self = most.CompareTo((object)most);
+            compare_most_to_another_instance_of_most = most.CompareTo((object)another_instance_of_most);
+            compare_least_to_object_of_another_type = most.CompareTo(new object());
+        };
+
+        It determines_least_is_less_than_most = () => compare_least_to_most.ShouldEqual(given.comparable_concepts.LESS_THAN);
+        It determines_least_is_less_than_middle = () => compare_least_to_middle.ShouldEqual(given.comparable_concepts.LESS_THAN);
+        It determines_least_is_equal_to_itself = () => compare_least_to_self.ShouldEqual(given.comparable_concepts.EQUAL);
+        It determines_middle_is_greater_than_least = () => compare_middle_to_least.ShouldEqual(given.comparable_concepts.GREATER_THAN);
+        It determines_middle_is_less_than_most = () => compare_middle_to_most.ShouldEqual(given.comparable_concepts.LESS_THAN);
+        It determines_middle_is_equal_to_itself = () => compare_middle_to_self.ShouldEqual(given.comparable_concepts.EQUAL);
+        It determines_most_is_greater_than_least = () => compare_most_to_least.ShouldEqual(given.comparable_concepts.GREATER_THAN);
+        It determines_most_is_greater_than_middle = () => compare_most_to_middle.ShouldEqual(given.comparable_concepts.GREATER_THAN);
+        It determines_most_is_equal_to_itself = () => compare_most_to_self.ShouldEqual(given.comparable_concepts.EQUAL);
+        It determines_most_is_equal_to_another_instance_of_most = () => compare_most_to_another_instance_of_most.ShouldEqual(given.comparable_concepts.EQUAL);
+        It determines_most_is_greater_than_object_of_another_type = () => compare_least_to_object_of_another_type.ShouldEqual(given.comparable_concepts.GREATER_THAN);
+    }    
 }

--- a/Specifications/Concepts/for_ConceptAs/when_comparing_on_generic_method.cs
+++ b/Specifications/Concepts/for_ConceptAs/when_comparing_on_generic_method.cs
@@ -31,36 +31,4 @@ namespace Dolittle.Specs.Concepts.for_ConceptAs
         It determines_most_is_equal_to_itself = () => compare_most_to_self.ShouldEqual(given.comparable_concepts.EQUAL);
         It determines_most_is_equal_to_another_instance_of_most = () => compare_most_to_another_instance_of_most.ShouldEqual(given.comparable_concepts.EQUAL);
     }
-
-    [Subject(typeof(ConceptAs<>))]
-    public class when_comparing_on_non_generic_method : given.comparable_concepts
-    {
-        static int compare_least_to_object_of_another_type;
-        Because of = () =>
-        {
-            compare_least_to_most = least.CompareTo((object)most);
-            compare_least_to_middle = least.CompareTo((object)middle);
-            compare_least_to_self = least.CompareTo((object)least);
-            compare_middle_to_least = middle.CompareTo((object)least);
-            compare_middle_to_most = middle.CompareTo((object)most);
-            compare_middle_to_self = middle.CompareTo((object)middle);
-            compare_most_to_least = most.CompareTo((object)least);
-            compare_most_to_middle = most.CompareTo((object)middle);
-            compare_most_to_self = most.CompareTo((object)most);
-            compare_most_to_another_instance_of_most = most.CompareTo((object)another_instance_of_most);
-            compare_least_to_object_of_another_type = most.CompareTo(new object());
-        };
-
-        It determines_least_is_less_than_most = () => compare_least_to_most.ShouldEqual(given.comparable_concepts.LESS_THAN);
-        It determines_least_is_less_than_middle = () => compare_least_to_middle.ShouldEqual(given.comparable_concepts.LESS_THAN);
-        It determines_least_is_equal_to_itself = () => compare_least_to_self.ShouldEqual(given.comparable_concepts.EQUAL);
-        It determines_middle_is_greater_than_least = () => compare_middle_to_least.ShouldEqual(given.comparable_concepts.GREATER_THAN);
-        It determines_middle_is_less_than_most = () => compare_middle_to_most.ShouldEqual(given.comparable_concepts.LESS_THAN);
-        It determines_middle_is_equal_to_itself = () => compare_middle_to_self.ShouldEqual(given.comparable_concepts.EQUAL);
-        It determines_most_is_greater_than_least = () => compare_most_to_least.ShouldEqual(given.comparable_concepts.GREATER_THAN);
-        It determines_most_is_greater_than_middle = () => compare_most_to_middle.ShouldEqual(given.comparable_concepts.GREATER_THAN);
-        It determines_most_is_equal_to_itself = () => compare_most_to_self.ShouldEqual(given.comparable_concepts.EQUAL);
-        It determines_most_is_equal_to_another_instance_of_most = () => compare_most_to_another_instance_of_most.ShouldEqual(given.comparable_concepts.EQUAL);
-        It determines_most_is_greater_than_object_of_another_type = () => compare_least_to_object_of_another_type.ShouldEqual(given.comparable_concepts.GREATER_THAN);
-    }    
 }

--- a/Specifications/Concepts/for_ConceptAs/when_comparing_on_generic_method.cs
+++ b/Specifications/Concepts/for_ConceptAs/when_comparing_on_generic_method.cs
@@ -1,0 +1,34 @@
+﻿using Dolittle.Concepts;
+using Machine.Specifications;
+
+namespace Dolittle.Specs.Concepts.for_ConceptAs
+{
+    [Subject(typeof(ConceptAs<>))]
+    public class when_comparing_on_generic_method : given.comparable_concepts
+    {
+        Because of = () =>
+        {
+            compare_least_to_most = least.CompareTo(most);
+            compare_least_to_middle = least.CompareTo(middle);
+            compare_least_to_self = least.CompareTo(least);
+            compare_middle_to_least = middle.CompareTo(least);
+            compare_middle_to_most = middle.CompareTo(most);
+            compare_middle_to_self = middle.CompareTo(middle);
+            compare_most_to_least = most.CompareTo(least);
+            compare_most_to_middle = most.CompareTo(middle);
+            compare_most_to_self = most.CompareTo(most);
+            compare_most_to_another_instance_of_most = most.CompareTo(another_instance_of_most);
+        };
+
+        It determines_least_is_less_than_most = () => compare_least_to_most.ShouldEqual(given.comparable_concepts.LESS_THAN);
+        It determines_least_is_less_than_middle = () => compare_least_to_middle.ShouldEqual(given.comparable_concepts.LESS_THAN);
+        It determines_least_is_equal_to_itself = () => compare_least_to_self.ShouldEqual(given.comparable_concepts.EQUAL);
+        It determines_middle_is_greater_than_least = () => compare_middle_to_least.ShouldEqual(given.comparable_concepts.GREATER_THAN);
+        It determines_middle_is_less_than_most = () => compare_middle_to_most.ShouldEqual(given.comparable_concepts.LESS_THAN);
+        It determines_middle_is_equal_to_itself = () => compare_middle_to_self.ShouldEqual(given.comparable_concepts.EQUAL);
+        It determines_most_is_greater_than_least = () => compare_most_to_least.ShouldEqual(given.comparable_concepts.GREATER_THAN);
+        It determines_most_is_greater_than_middle = () => compare_most_to_middle.ShouldEqual(given.comparable_concepts.GREATER_THAN);
+        It determines_most_is_equal_to_itself = () => compare_most_to_self.ShouldEqual(given.comparable_concepts.EQUAL);
+        It determines_most_is_equal_to_another_instance_of_most = () => compare_most_to_another_instance_of_most.ShouldEqual(given.comparable_concepts.EQUAL);
+    }
+}

--- a/Specifications/Concepts/for_ConceptAs/when_comparing_on_non_generic_method.cs
+++ b/Specifications/Concepts/for_ConceptAs/when_comparing_on_non_generic_method.cs
@@ -1,0 +1,37 @@
+using Dolittle.Concepts;
+using Machine.Specifications;
+
+namespace Dolittle.Specs.Concepts.for_ConceptAs
+{
+    [Subject(typeof(ConceptAs<>))]
+    public class when_comparing_on_non_generic_method : given.comparable_concepts
+    {
+        static int compare_least_to_object_of_another_type;
+        Because of = () =>
+        {
+            compare_least_to_most = least.CompareTo((object)most);
+            compare_least_to_middle = least.CompareTo((object)middle);
+            compare_least_to_self = least.CompareTo((object)least);
+            compare_middle_to_least = middle.CompareTo((object)least);
+            compare_middle_to_most = middle.CompareTo((object)most);
+            compare_middle_to_self = middle.CompareTo((object)middle);
+            compare_most_to_least = most.CompareTo((object)least);
+            compare_most_to_middle = most.CompareTo((object)middle);
+            compare_most_to_self = most.CompareTo((object)most);
+            compare_most_to_another_instance_of_most = most.CompareTo((object)another_instance_of_most);
+            compare_least_to_object_of_another_type = most.CompareTo(new object());
+        };
+
+        It determines_least_is_less_than_most = () => compare_least_to_most.ShouldEqual(given.comparable_concepts.LESS_THAN);
+        It determines_least_is_less_than_middle = () => compare_least_to_middle.ShouldEqual(given.comparable_concepts.LESS_THAN);
+        It determines_least_is_equal_to_itself = () => compare_least_to_self.ShouldEqual(given.comparable_concepts.EQUAL);
+        It determines_middle_is_greater_than_least = () => compare_middle_to_least.ShouldEqual(given.comparable_concepts.GREATER_THAN);
+        It determines_middle_is_less_than_most = () => compare_middle_to_most.ShouldEqual(given.comparable_concepts.LESS_THAN);
+        It determines_middle_is_equal_to_itself = () => compare_middle_to_self.ShouldEqual(given.comparable_concepts.EQUAL);
+        It determines_most_is_greater_than_least = () => compare_most_to_least.ShouldEqual(given.comparable_concepts.GREATER_THAN);
+        It determines_most_is_greater_than_middle = () => compare_most_to_middle.ShouldEqual(given.comparable_concepts.GREATER_THAN);
+        It determines_most_is_equal_to_itself = () => compare_most_to_self.ShouldEqual(given.comparable_concepts.EQUAL);
+        It determines_most_is_equal_to_another_instance_of_most = () => compare_most_to_another_instance_of_most.ShouldEqual(given.comparable_concepts.EQUAL);
+        It determines_most_is_greater_than_object_of_another_type = () => compare_least_to_object_of_another_type.ShouldEqual(given.comparable_concepts.GREATER_THAN);
+    }    
+}

--- a/Specifications/Concepts/for_ConceptAs/when_equating.cs
+++ b/Specifications/Concepts/for_ConceptAs/when_equating.cs
@@ -4,7 +4,7 @@ using Machine.Specifications;
 namespace Dolittle.Specs.Concepts.for_ConceptAs
 {
     [Subject(typeof(ConceptAs<>))]
-    public class when_equating : given.concepts
+    public class when_equating : Dolittle.Specs.Concepts.given.concepts
     {
         static bool result_of_equality;
         static bool result_of_operator_equality;

--- a/Specifications/Concepts/for_ConceptAs/when_getting_hash_code.cs
+++ b/Specifications/Concepts/for_ConceptAs/when_getting_hash_code.cs
@@ -4,7 +4,7 @@ using Machine.Specifications;
 namespace Dolittle.Specs.Concepts.for_ConceptAs
 {
     [Subject(typeof(ConceptAs<>))]
-    public class when_getting_hash_code : given.concepts
+    public class when_getting_hash_code : Dolittle.Specs.Concepts.given.concepts
     {
         static bool hash_codes_of_different_values_are_different;
         static bool hash_codes_of_same_values_are_the_same;

--- a/Specifications/Concepts/for_ConceptExtensions/when_checking_is_concept_on_a_concept.cs
+++ b/Specifications/Concepts/for_ConceptExtensions/when_checking_is_concept_on_a_concept.cs
@@ -5,7 +5,7 @@ using Machine.Specifications;
 namespace Dolittle.Specs.Concepts.for_ConceptExtensions
 {
     [Subject(typeof (ConceptExtensions))]
-    public class when_checking_is_concept_on_a_concept : given.concepts
+    public class when_checking_is_concept_on_a_concept : Dolittle.Specs.Concepts.given.concepts
     {
         static bool is_a_concept;
 

--- a/Specifications/Concepts/for_ConceptExtensions/when_checking_is_concept_on_a_concept_instance.cs
+++ b/Specifications/Concepts/for_ConceptExtensions/when_checking_is_concept_on_a_concept_instance.cs
@@ -4,7 +4,7 @@ using Machine.Specifications;
 namespace Dolittle.Specs.Concepts.for_ConceptExtensions
 {
     [Subject(typeof(ConceptExtensions))]
-    public class when_checking_is_concept_on_a_concept_instance : given.concepts
+    public class when_checking_is_concept_on_a_concept_instance : Dolittle.Specs.Concepts.given.concepts
     {
         static bool is_a_concept;
 

--- a/Specifications/Concepts/for_ConceptExtensions/when_checking_is_concept_on_a_primitive.cs
+++ b/Specifications/Concepts/for_ConceptExtensions/when_checking_is_concept_on_a_primitive.cs
@@ -4,7 +4,7 @@ using Machine.Specifications;
 namespace Dolittle.Specs.Concepts.for_ConceptExtensions
 {
     [Subject(typeof(ConceptExtensions))]
-    public class when_checking_is_concept_on_a_primitive : given.concepts
+    public class when_checking_is_concept_on_a_primitive : Dolittle.Specs.Concepts.given.concepts
     {
         static bool is_a_concept;
 

--- a/Specifications/Concepts/for_ConceptExtensions/when_checking_is_concept_on_a_primitive_instance.cs
+++ b/Specifications/Concepts/for_ConceptExtensions/when_checking_is_concept_on_a_primitive_instance.cs
@@ -4,7 +4,7 @@ using Machine.Specifications;
 namespace Dolittle.Specs.Concepts.for_ConceptExtensions
 {
     [Subject(typeof(ConceptExtensions))]
-    public class when_checking_is_concept_on_a_primitive_instance : given.concepts
+    public class when_checking_is_concept_on_a_primitive_instance : Dolittle.Specs.Concepts.given.concepts
     {
         static bool is_a_concept;
 

--- a/Specifications/Concepts/for_ConceptExtensions/when_checking_is_concept_on_an_inherited_concept_instance.cs
+++ b/Specifications/Concepts/for_ConceptExtensions/when_checking_is_concept_on_an_inherited_concept_instance.cs
@@ -4,7 +4,7 @@ using Machine.Specifications;
 namespace Dolittle.Specs.Concepts.for_ConceptExtensions
 {
     [Subject(typeof(ConceptExtensions))]
-    public class when_checking_is_concept_on_an_inherited_concept_instance : given.concepts
+    public class when_checking_is_concept_on_an_inherited_concept_instance : Dolittle.Specs.Concepts.given.concepts
     {
         static bool is_a_concept;
 

--- a/Specifications/Concepts/for_ConceptExtensions/when_getting_the_value_from_a_long_concept.cs
+++ b/Specifications/Concepts/for_ConceptExtensions/when_getting_the_value_from_a_long_concept.cs
@@ -1,10 +1,11 @@
 ﻿using Dolittle.Concepts;
+using Dolittle.Specs.Concepts.given;
 using Machine.Specifications;
 
 namespace Dolittle.Specs.Concepts.for_ConceptExtensions
 {
     [Subject(typeof(ConceptExtensions))]
-    public class when_getting_the_value_from_a_long_concept : given.concepts
+    public class when_getting_the_value_from_a_long_concept : concepts
     {
         static LongConcept value;
         static long primitive_value = 10;

--- a/Specifications/Concepts/for_ConceptExtensions/when_getting_the_value_from_a_multilevel_inherited_concept.cs
+++ b/Specifications/Concepts/for_ConceptExtensions/when_getting_the_value_from_a_multilevel_inherited_concept.cs
@@ -1,10 +1,11 @@
 ﻿using Dolittle.Concepts;
+using Dolittle.Specs.Concepts.given;
 using Machine.Specifications;
 
 namespace Dolittle.Specs.Concepts.for_ConceptExtensions
 {
     [Subject(typeof(ConceptExtensions))]
-    public class when_getting_the_value_from_a_multilevel_inherited_concept : given.concepts
+    public class when_getting_the_value_from_a_multilevel_inherited_concept : concepts
     {
         static MultiLevelInheritanceConcept value;
         static long primitive_value = 100;

--- a/Specifications/Concepts/for_ConceptExtensions/when_getting_the_value_from_a_non_concept.cs
+++ b/Specifications/Concepts/for_ConceptExtensions/when_getting_the_value_from_a_non_concept.cs
@@ -1,11 +1,12 @@
 ﻿using System;
 using Dolittle.Concepts;
+using Dolittle.Specs.Concepts.given;
 using Machine.Specifications;
 
 namespace Dolittle.Specs.Concepts.for_ConceptExtensions
 {
     [Subject(typeof(ConceptExtensions))]
-    public class when_getting_the_value_from_a_non_concept : given.concepts
+    public class when_getting_the_value_from_a_non_concept : concepts
     {
         static string primitive_value = "ten";
         static Exception exception;

--- a/Specifications/Concepts/for_ConceptExtensions/when_getting_the_value_from_a_string_concept.cs
+++ b/Specifications/Concepts/for_ConceptExtensions/when_getting_the_value_from_a_string_concept.cs
@@ -1,10 +1,11 @@
 ﻿using Dolittle.Concepts;
 using Machine.Specifications;
+using Dolittle.Specs.Concepts.given;
 
 namespace Dolittle.Specs.Concepts.for_ConceptExtensions
 {
     [Subject(typeof(ConceptExtensions))]
-    public class when_getting_the_value_from_a_string_concept : given.concepts
+    public class when_getting_the_value_from_a_string_concept : concepts
     {
         static StringConcept value;
         static string primitive_value = "ten";

--- a/Specifications/Concepts/for_ConceptExtensions/when_getting_the_value_from_an_inherited_concept.cs
+++ b/Specifications/Concepts/for_ConceptExtensions/when_getting_the_value_from_an_inherited_concept.cs
@@ -1,10 +1,11 @@
 ﻿using Dolittle.Concepts;
 using Machine.Specifications;
+using Dolittle.Specs.Concepts.given;
 
 namespace Dolittle.Specs.Concepts.for_ConceptExtensions
 {
     [Subject(typeof(ConceptExtensions))]
-    public class when_getting_the_value_from_an_inherited_concept : given.concepts
+    public class when_getting_the_value_from_an_inherited_concept : concepts
     {
         static InheritingFromLongConcept value;
         static long primitive_value = 100;

--- a/Specifications/Concepts/for_ConceptMap/when_getting_the_primitive_type_from_a_guid_concept.cs
+++ b/Specifications/Concepts/for_ConceptMap/when_getting_the_primitive_type_from_a_guid_concept.cs
@@ -10,7 +10,7 @@ namespace Dolittle.Specs.Concepts.for_ConceptMap
     {
         static Type result;
 
-        Because of = () => result = ConceptMap.GetConceptValueType(typeof(concepts.GuidConcept));
+        Because of = () => result = ConceptMap.GetConceptValueType(typeof(GuidConcept));
 
         It should_get_a_guid = () => result.ShouldEqual(typeof(Guid));
     }

--- a/Specifications/Concepts/for_ConceptMap/when_getting_the_primitive_type_from_a_long_concept.cs
+++ b/Specifications/Concepts/for_ConceptMap/when_getting_the_primitive_type_from_a_long_concept.cs
@@ -10,7 +10,7 @@ namespace Dolittle.Specs.Concepts.for_ConceptMap
     {
         static Type result;
 
-        Because of = () => result = ConceptMap.GetConceptValueType(typeof(concepts.LongConcept));
+        Because of = () => result = ConceptMap.GetConceptValueType(typeof(LongConcept));
 
         It should_get_a_long = () => result.ShouldEqual(typeof(long));
     }

--- a/Specifications/Concepts/for_ConceptMap/when_getting_the_primitive_type_from_a_string_concept.cs
+++ b/Specifications/Concepts/for_ConceptMap/when_getting_the_primitive_type_from_a_string_concept.cs
@@ -10,7 +10,7 @@ namespace Dolittle.Specs.Concepts.for_ConceptMap
     {
         static Type result;
 
-        Because of = () => result = ConceptMap.GetConceptValueType(typeof (concepts.StringConcept));
+        Because of = () => result = ConceptMap.GetConceptValueType(typeof(StringConcept));
 
         It should_get_a_string = () => result.ShouldEqual(typeof(string));
     }

--- a/Specifications/Concepts/for_ConceptMap/when_getting_the_primitive_type_from_a_type_that_is_not_a_concept.cs
+++ b/Specifications/Concepts/for_ConceptMap/when_getting_the_primitive_type_from_a_type_that_is_not_a_concept.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Dolittle.Concepts;
 using Machine.Specifications;
+using Dolittle.Specs.Concepts.given;
 
 namespace Dolittle.Specs.Concepts.for_ConceptMap
 {

--- a/Specifications/Concepts/for_ConceptMap/when_getting_the_primitive_type_from_an_inherited_concept_based_on_a_long.cs
+++ b/Specifications/Concepts/for_ConceptMap/when_getting_the_primitive_type_from_an_inherited_concept_based_on_a_long.cs
@@ -10,7 +10,7 @@ namespace Dolittle.Specs.Concepts.for_ConceptMap
     {
         static Type result;
 
-        Because of = () => result = ConceptMap.GetConceptValueType(typeof(concepts.InheritingFromLongConcept));
+        Because of = () => result = ConceptMap.GetConceptValueType(typeof(InheritingFromLongConcept));
 
         It should_get_a_long = () => result.ShouldEqual(typeof(long));
     }

--- a/Specifications/Concepts/for_ConceptMap/when_getting_the_primitive_type_from_an_multilevel_inheritance_concept_based_on_a_long.cs
+++ b/Specifications/Concepts/for_ConceptMap/when_getting_the_primitive_type_from_an_multilevel_inheritance_concept_based_on_a_long.cs
@@ -10,7 +10,7 @@ namespace Dolittle.Specs.Concepts.for_ConceptMap
     {
         static Type result;
 
-        Because of = () => result = ConceptMap.GetConceptValueType(typeof(concepts.MultiLevelInheritanceConcept));
+        Because of = () => result = ConceptMap.GetConceptValueType(typeof(MultiLevelInheritanceConcept));
 
         It should_get_a_long = () => result.ShouldEqual(typeof(long));
     }

--- a/Specifications/Concepts/given/GuidConcept.cs
+++ b/Specifications/Concepts/given/GuidConcept.cs
@@ -1,0 +1,13 @@
+using System;
+using Dolittle.Concepts;
+
+namespace Dolittle.Specs.Concepts.given
+{
+    public class GuidConcept : ConceptAs<Guid>
+    {
+        public static implicit operator GuidConcept(Guid value)
+        {
+            return new GuidConcept { Value = value };
+        }
+    }
+}

--- a/Specifications/Concepts/given/InheritingFromLongConcept.cs
+++ b/Specifications/Concepts/given/InheritingFromLongConcept.cs
@@ -1,0 +1,10 @@
+namespace Dolittle.Specs.Concepts.given
+{
+    public class InheritingFromLongConcept : LongConcept
+    {
+        public static implicit operator InheritingFromLongConcept(long value)
+        {
+            return new InheritingFromLongConcept { Value = value };
+        }
+    }
+}

--- a/Specifications/Concepts/given/IntConcept.cs
+++ b/Specifications/Concepts/given/IntConcept.cs
@@ -1,0 +1,22 @@
+using Dolittle.Concepts;
+
+namespace Dolittle.Specs.Concepts.given
+{
+    public class IntConcept : ConceptAs<int>
+    {
+        public IntConcept()
+        {
+
+        }
+
+        public IntConcept(int value)
+        {
+            Value = value;
+        }
+
+        public static implicit operator IntConcept(int value)
+        {
+            return new IntConcept { Value = value };
+        }
+    }
+}

--- a/Specifications/Concepts/given/LongConcept.cs
+++ b/Specifications/Concepts/given/LongConcept.cs
@@ -1,0 +1,12 @@
+using Dolittle.Concepts;
+
+namespace Dolittle.Specs.Concepts.given
+{
+    public class LongConcept : ConceptAs<long>
+    {
+        public static implicit operator LongConcept(long value)
+        {
+            return new LongConcept { Value = value };
+        }
+    }
+}

--- a/Specifications/Concepts/given/MultiLevelInheritanceConcept.cs
+++ b/Specifications/Concepts/given/MultiLevelInheritanceConcept.cs
@@ -1,0 +1,10 @@
+namespace Dolittle.Specs.Concepts.given
+{
+    public class MultiLevelInheritanceConcept : InheritingFromLongConcept
+    {
+        public static implicit operator MultiLevelInheritanceConcept(long value)
+        {
+            return new MultiLevelInheritanceConcept { Value = value };
+        }
+    }
+}

--- a/Specifications/Concepts/given/StringConcept.cs
+++ b/Specifications/Concepts/given/StringConcept.cs
@@ -1,0 +1,12 @@
+using Dolittle.Concepts;
+
+namespace Dolittle.Specs.Concepts.given
+{
+    public class StringConcept : ConceptAs<string>
+    {
+        public static implicit operator StringConcept(string value)
+        {
+            return new StringConcept { Value = value };
+        }
+    }
+}

--- a/Specifications/Concepts/given/concepts.cs
+++ b/Specifications/Concepts/given/concepts.cs
@@ -1,5 +1,3 @@
-using System;
-using Dolittle.Concepts;
 using Machine.Specifications;
 
 namespace Dolittle.Specs.Concepts.given
@@ -30,53 +28,5 @@ namespace Dolittle.Specs.Concepts.given
                 value_as_a_long_inherited = 1;
                 empty_long_value = 0;
             };
-
-        public class StringConcept : ConceptAs<string>
-        {
-            public static implicit operator StringConcept(string value)
-            {
-                return new StringConcept { Value = value };
-            }
-        }
-
-        public class IntConcept : ConceptAs<int>
-        {
-            public static implicit operator IntConcept(int value)
-            {
-                return new IntConcept { Value = value };
-            }
-        }
-
-        public class LongConcept : ConceptAs<long>
-        {
-            public static implicit operator LongConcept(long value)
-            {
-                return new LongConcept { Value = value };
-            }
-        }
-
-        public class GuidConcept : ConceptAs<Guid>
-        {
-            public static implicit operator GuidConcept(Guid value)
-            {
-                return new GuidConcept { Value = value };
-            }
-        }
-
-        public class InheritingFromLongConcept : LongConcept
-        {
-            public static implicit operator InheritingFromLongConcept(long value)
-            {
-                return new InheritingFromLongConcept { Value = value };
-            }
-        }
-
-        public class MultiLevelInheritanceConcept : InheritingFromLongConcept
-        {
-            public static implicit operator MultiLevelInheritanceConcept(long value)
-            {
-                return new MultiLevelInheritanceConcept { Value = value };
-            }
-        }
     }
 }


### PR DESCRIPTION
I think we should be able to treat a Concept as the underlying primitive, so you often want to do >, <=, etc..

It turns out that you can compare Guids, to get a less than, greater than, etc.  I'm not sure how useful that is but it's there anyway.

Since we can't make operator overloads virtual, you can't override them.  The underlying CompareTo methods are virtual though so you can override them.