### PR TITLE
Property bag

### DIFF
--- a/Source/Dynamic/Dynamic.csproj
+++ b/Source/Dynamic/Dynamic.csproj
@@ -9,6 +9,9 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.3.0" />
     <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
   </ItemGroup>
-
+  <ItemGroup>
+    <ProjectReference Include="..\Concepts\Concepts.csproj" />
+    <ProjectReference Include="..\Immutability\Immutability.csproj" />
+  </ItemGroup>
   <Import Project="../../Build/MSBuild/default.props"></Import>
 </Project>

--- a/Source/Dynamic/ObjectExtensions.cs
+++ b/Source/Dynamic/ObjectExtensions.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Dolittle.Concepts;
+using Dolittle.Reflection;
+
+namespace Dolittle.Dynamic
+{
+    /// <summary>
+    /// Extensions for object
+    /// </summary>
+    public static class ObjectExtensions
+    {
+        /// <summary>
+        /// Creates a <see cref="PropertyBag"/> from an object.
+        /// Maps primitive properties and complex objects to <see cref="PropertyBag"/> recursively
+        /// </summary>
+        /// <param name="obj">Object to convert</param>
+        /// <returns></returns>
+        public static PropertyBag ToPropertyBag(this object obj)
+        {
+            if(obj == null)
+                return null;
+            
+            Dictionary<string,object> values = new Dictionary<string, object>();
+
+            foreach (var property in obj.GetType().GetProperties(BindingFlags.Instance | BindingFlags.Public))
+            {
+                var value = property.PropertyType.IsAPrimitiveType() ? property.GetValue(obj) : property.PropertyType.IsConcept() ? property.GetValue(obj).GetConceptValue() : property.GetValue(obj).ToPropertyBag();
+                values.Add(property.Name, value);
+            }
+
+            return new PropertyBag(values);    
+        }
+    }
+}

--- a/Source/Dynamic/PropertyBag.cs
+++ b/Source/Dynamic/PropertyBag.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Generic;
+
+namespace Dolittle.Dynamic
+{
+    /// <summary>
+    /// An immutable property bag of key-value pairs
+    /// </summary>
+    public class PropertyBag : WriteOnceExpandoObject
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="values"></param>
+        public PropertyBag(IDictionary<string,object> values) : base(values)
+        {
+        }
+    }
+}

--- a/Source/Dynamic/WriteOnceExpandoObject.cs
+++ b/Source/Dynamic/WriteOnceExpandoObject.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Dynamic;
+using Dolittle.Immutability;
 
 namespace Dolittle.Dynamic
 {
@@ -13,7 +14,7 @@ namespace Dolittle.Dynamic
     /// Represents an ExpandoObject that can only have values assigned to during creation.
     /// Similar to <see cref="ExpandoObject"/>, members are dynamic and can be added on the fly
     /// </summary>
-    public class WriteOnceExpandoObject : DynamicObject, IDictionary<string, object>
+    public class WriteOnceExpandoObject : DynamicObject, IDictionary<string, object>, IAmImmutable
     {
         Dictionary<string, object> _actualDictionary = new Dictionary<string, object>();
         bool _construction;
@@ -26,6 +27,20 @@ namespace Dolittle.Dynamic
         {
             _construction = true;
             populate(this);
+            _construction = false;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of <see cref="WriteOnceExpandoObject"/>
+        /// </summary>
+        /// <param name="values">A dictionary of values used to populate the object</param>
+        public WriteOnceExpandoObject(IDictionary<string,object> values)
+        {
+            _construction = true;
+            foreach(var v in values)
+            {
+                Add(v.Key,v.Value);
+            }
             _construction = false;
         }
 
@@ -138,7 +153,7 @@ namespace Dolittle.Dynamic
         void ThrowIfNotUnderConstruction()
         {
             if( !_construction )
-                throw new ReadOnlyObjectException();
+                throw new CannotWriteToAnImmutable();
         }
     }
 }

--- a/Source/Immutability/CannotWriteToAnImmutable.cs
+++ b/Source/Immutability/CannotWriteToAnImmutable.cs
@@ -4,12 +4,12 @@
  *--------------------------------------------------------------------------------------------*/
 using System;
 
-namespace Dolittle.Dynamic
+namespace Dolittle.Immutability
 {
     /// <summary>
     /// The exception that is thrown when an object is read only and one is writing to it
     /// </summary>
-    public class ReadOnlyObjectException : ArgumentException
+    public class CannotWriteToAnImmutable : ArgumentException
     {
     }
 }

--- a/Source/Immutability/IAmImmutable.cs
+++ b/Source/Immutability/IAmImmutable.cs
@@ -1,0 +1,10 @@
+namespace Dolittle.Immutability
+{
+    /// <summary>
+    /// A marker interface to indicate that an object is immutable
+    /// </summary>
+    public interface IAmImmutable
+    {
+         
+    }
+}

--- a/Source/Immutability/Immutability.csproj
+++ b/Source/Immutability/Immutability.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <AssemblyName>Dolittle.Immutability</AssemblyName>
+  </PropertyGroup>
+
+  <Import Project="../../Build/MSBuild/default.props"/>
+
+</Project>

--- a/Source/Reflection/TypeExtensions.cs
+++ b/Source/Reflection/TypeExtensions.cs
@@ -212,7 +212,7 @@ namespace Dolittle.Reflection
         public static bool IsAPrimitiveType(this Type type)
         {
             return type.GetTypeInfo().IsPrimitive 
-                    || type.IsNullable() || AdditionalPrimitiveTypes.Contains(type) || type == typeof(decimal);
+                    || type.IsNullable() || AdditionalPrimitiveTypes.Contains(type);
         }
 
 

--- a/Specifications/Dynamic/for_ObjectExtensions/for_ToPropertyBag/ConceptDto.cs
+++ b/Specifications/Dynamic/for_ObjectExtensions/for_ToPropertyBag/ConceptDto.cs
@@ -1,0 +1,13 @@
+using System;
+using Dolittle.Concepts;
+using Dolittle.Dynamic;
+using Machine.Specifications;
+
+namespace Dolittle.Dynamic.for_ObjectExtensions.for_ToPropertyBag
+{
+    internal class ConceptDto 
+    {
+        public StringConcept StringConcept { get; set; }
+        public LongConcept LongConcept { get; set; }
+    }
+}

--- a/Specifications/Dynamic/for_ObjectExtensions/for_ToPropertyBag/LongConcept.cs
+++ b/Specifications/Dynamic/for_ObjectExtensions/for_ToPropertyBag/LongConcept.cs
@@ -1,0 +1,15 @@
+using System;
+using Dolittle.Concepts;
+using Dolittle.Dynamic;
+using Machine.Specifications;
+
+namespace Dolittle.Dynamic.for_ObjectExtensions.for_ToPropertyBag
+{
+
+    public class LongConcept : ConceptAs<long>
+    {
+        public LongConcept(long value) => Value = value;
+    
+        public static implicit operator LongConcept(long value) => new LongConcept(value);
+    }
+}

--- a/Specifications/Dynamic/for_ObjectExtensions/for_ToPropertyBag/NestedDto.cs
+++ b/Specifications/Dynamic/for_ObjectExtensions/for_ToPropertyBag/NestedDto.cs
@@ -1,0 +1,13 @@
+using System;
+using Dolittle.Concepts;
+using Dolittle.Dynamic;
+using Machine.Specifications;
+
+namespace Dolittle.Dynamic.for_ObjectExtensions.for_ToPropertyBag
+{
+
+    internal class NestedDto : SimpleDto
+    {   
+        public SimpleDto Child { get; set; } 
+    }
+}

--- a/Specifications/Dynamic/for_ObjectExtensions/for_ToPropertyBag/SimpleDto.cs
+++ b/Specifications/Dynamic/for_ObjectExtensions/for_ToPropertyBag/SimpleDto.cs
@@ -1,0 +1,15 @@
+using System;
+using Dolittle.Concepts;
+using Dolittle.Dynamic;
+using Machine.Specifications;
+
+namespace Dolittle.Dynamic.for_ObjectExtensions.for_ToPropertyBag
+{
+
+    internal class SimpleDto 
+    {
+        public string String { get; set; }
+        public int Int { get; set; }
+        public DateTime DateTime { get; set; }
+    }
+}

--- a/Specifications/Dynamic/for_ObjectExtensions/for_ToPropertyBag/StringConcept.cs
+++ b/Specifications/Dynamic/for_ObjectExtensions/for_ToPropertyBag/StringConcept.cs
@@ -1,0 +1,15 @@
+using System;
+using Dolittle.Concepts;
+using Dolittle.Dynamic;
+using Machine.Specifications;
+
+namespace Dolittle.Dynamic.for_ObjectExtensions.for_ToPropertyBag
+{
+
+    public class StringConcept : ConceptAs<string>
+    {
+        public StringConcept(string value) => Value = value;
+    
+        public static implicit operator StringConcept(string value) => new StringConcept(value);
+    }
+}

--- a/Specifications/Dynamic/for_ObjectExtensions/for_ToPropertyBag/when_converting_a_dto_with_a_nested_complex_type.cs
+++ b/Specifications/Dynamic/for_ObjectExtensions/for_ToPropertyBag/when_converting_a_dto_with_a_nested_complex_type.cs
@@ -1,0 +1,34 @@
+using System;
+using Dolittle.Dynamic;
+using Machine.Specifications;
+
+namespace Dolittle.Dynamic.for_ObjectExtensions.for_ToPropertyBag
+{
+    [Subject("ToPropertyBag")]
+    public class when_converting_a_dto_with_a_nested_complex_type
+    {
+        static NestedDto source;
+        static dynamic result;
+
+        Establish context = () => { source = new NestedDto{ String = "hello", Int = 23, DateTime = DateTime.Now, Child = new SimpleDto { String = "Nested", Int = 46, DateTime = DateTime.Now.AddDays(1)} };};
+
+        Because of = () => result = source.ToPropertyBag();
+
+        It should_create_a_property_bag = () => (result as PropertyBag).ShouldNotBeNull();
+        It should_have_the_primitive_properties = () =>
+        {
+            ShouldExtensionMethods.ShouldEqual(result.String,source.String);
+            ShouldExtensionMethods.ShouldEqual(result.Int,source.Int);
+            ShouldExtensionMethods.ShouldEqual(result.DateTime,source.DateTime);
+        };
+
+        It should_have_the_complex_type_as_a_property_bag = () => (result.Child as PropertyBag).ShouldNotBeNull();
+
+        It should_have_the_correct_properties_on_the_complex_type = () =>
+        {
+            ShouldExtensionMethods.ShouldEqual(result.Child.String,source.Child.String);
+            ShouldExtensionMethods.ShouldEqual(result.Child.Int,source.Child.Int);
+            ShouldExtensionMethods.ShouldEqual(result.Child.DateTime,source.Child.DateTime);
+        };
+    }
+}

--- a/Specifications/Dynamic/for_ObjectExtensions/for_ToPropertyBag/when_converting_a_dto_with_concepts_as_properties.cs
+++ b/Specifications/Dynamic/for_ObjectExtensions/for_ToPropertyBag/when_converting_a_dto_with_concepts_as_properties.cs
@@ -1,0 +1,23 @@
+using Dolittle.Dynamic;
+using Machine.Specifications;
+
+namespace Dolittle.Dynamic.for_ObjectExtensions.for_ToPropertyBag
+{
+    [Subject("ToPropertyBag")]
+    public class when_converting_a_dto_with_concepts_as_properties
+    {
+        static ConceptDto source;
+        static dynamic result;
+
+        Establish context = () => { source = new ConceptDto{ StringConcept = "hello", LongConcept = long.MaxValue }; };
+
+        Because of = () => result = source.ToPropertyBag();
+
+        It should_create_a_property_bag = () => (result as PropertyBag).ShouldNotBeNull();
+        It should_have_the_primitive_value_from_the_concepts = () =>
+        {
+            ShouldExtensionMethods.ShouldEqual(result.StringConcept,source.StringConcept.Value);
+            ShouldExtensionMethods.ShouldEqual(result.LongConcept,source.LongConcept.Value);
+        };
+    }
+}

--- a/Specifications/Dynamic/for_ObjectExtensions/for_ToPropertyBag/when_converting_a_simple_dto_with_primitives_as_properties.cs
+++ b/Specifications/Dynamic/for_ObjectExtensions/for_ToPropertyBag/when_converting_a_simple_dto_with_primitives_as_properties.cs
@@ -1,0 +1,27 @@
+using System;
+using Dolittle.Concepts;
+using Dolittle.Dynamic;
+using Machine.Specifications;
+
+namespace Dolittle.Dynamic.for_ObjectExtensions.for_ToPropertyBag
+{
+
+    [Subject("ToPropertyBag")]
+    public class when_converting_a_simple_dto_with_primitives_as_properties
+    {
+        static SimpleDto source;
+        static dynamic result;
+
+        Establish context = () => source = new SimpleDto { String = "hello", Int = 23, DateTime = DateTime.Now };
+
+        Because of = () => result = source.ToPropertyBag();
+
+        It should_create_a_property_bag = () => (result as PropertyBag).ShouldNotBeNull();
+        It should_have_the_primitive_properties = () =>
+        {
+            ShouldExtensionMethods.ShouldEqual(result.String,source.String);
+            ShouldExtensionMethods.ShouldEqual(result.Int,source.Int);
+            ShouldExtensionMethods.ShouldEqual(result.DateTime,source.DateTime);
+        };
+    }
+}

--- a/Specifications/Dynamic/for_WriteOnceExpandoObject/a_read_only_container.cs
+++ b/Specifications/Dynamic/for_WriteOnceExpandoObject/a_read_only_container.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Machine.Specifications;
+using Dolittle.Immutability;
 
 namespace Dolittle.Dynamic.Specs.for_WriteOnceExpandoObject
 {
@@ -7,6 +8,6 @@ namespace Dolittle.Dynamic.Specs.for_WriteOnceExpandoObject
     public class a_read_only_container
     {
         protected static Exception exception;
-        It should_throw_a_read_only_object_exception = () => exception.ShouldBeOfExactType<ReadOnlyObjectException>();
+        It should_throw_a_read_only_object_exception = () => exception.ShouldBeOfExactType<CannotWriteToAnImmutable>();
     }
 }


### PR DESCRIPTION
The idea is that we have a basic key-value pair structure that can be used to serialize and deserialize.  If, for example, the event store works on PropertyBag rather than IEvent, we can persist in whatever format we want and have a standardized method for going back to the concrete type from the PropertyBag.