### PR TITLE
Fix Equals methods

### DIFF
--- a/Source/Applications/Application.cs
+++ b/Source/Applications/Application.cs
@@ -49,8 +49,8 @@ namespace Dolittle.Applications
         /// <inheritdoc/>
         public bool Equals(IApplication other)
         {
-            if (Name.Value != other.Name.Value) return false;
-            if (Structure != other.Structure) return false;
+            if (Name.Value.Equals(other.Name.Value)) return false;
+            if (Structure.Equals(other.Structure)) return false;
             // figure out what to do with Prefixes
             return true;
         }

--- a/Source/Applications/Application.cs
+++ b/Source/Applications/Application.cs
@@ -49,8 +49,8 @@ namespace Dolittle.Applications
         /// <inheritdoc/>
         public bool Equals(IApplication other)
         {
-            if (Name.Value.Equals(other.Name.Value)) return false;
-            if (Structure.Equals(other.Structure)) return false;
+            if (! Name.Value.Equals(other.Name.Value)) return false;
+            if (! Structure.Equals(other.Structure)) return false;
             // figure out what to do with Prefixes
             return true;
         }

--- a/Source/Applications/ApplicationArtifactIdentifier.cs
+++ b/Source/Applications/ApplicationArtifactIdentifier.cs
@@ -55,11 +55,11 @@ namespace Dolittle.Applications
         /// <inheritdoc/>
         public bool Equals(IApplicationArtifactIdentifier other)
         {
-            if (Location != other.Location) return false;
+            if (Location.Equals(other.Location)) return false;
 
-            if (Application.Name.Value != other.Application.Name.Value) return false;
+            if (Application.Equals(other.Application)) return false;
 
-            if (Artifact != other.Artifact) return false;
+            if (Artifact.Equals(other.Artifact)) return false;
 
             return true;
         }

--- a/Source/Applications/ApplicationArtifactIdentifier.cs
+++ b/Source/Applications/ApplicationArtifactIdentifier.cs
@@ -55,11 +55,11 @@ namespace Dolittle.Applications
         /// <inheritdoc/>
         public bool Equals(IApplicationArtifactIdentifier other)
         {
-            if (Location.Equals(other.Location)) return false;
+            if (! Location.Equals(other.Location)) return false;
 
-            if (Application.Equals(other.Application)) return false;
+            if (! Application.Equals(other.Application)) return false;
 
-            if (Artifact.Equals(other.Artifact)) return false;
+            if (! Artifact.Equals(other.Artifact)) return false;
 
             return true;
         }

--- a/Source/Applications/ApplicationLocation.cs
+++ b/Source/Applications/ApplicationLocation.cs
@@ -43,7 +43,15 @@ namespace Dolittle.Applications
         {
             if (Segments.Count() != other.Segments.Count()) return false;
             // Use Equals on each segment instead?
-            return GetHashCode().Equals(other.GetHashCode());
+            else 
+            {
+                foreach (var segment in Segments)
+                {
+                    if (! other.Segments.Any(otherSegment => segment.Equals(otherSegment))) return false;
+                }
+            }
+
+            return true;
         }
 
         /// <inheritdoc/>

--- a/Specifications/Applications/for_ApplicationArtifactIdentifier/given/MyArtifactType.cs
+++ b/Specifications/Applications/for_ApplicationArtifactIdentifier/given/MyArtifactType.cs
@@ -1,0 +1,14 @@
+using Dolittle.Artifacts;
+
+namespace Dolittle.Applications.Specs.for_ApplicationArtifactIdentifier.given
+{
+    public class MyArtifactType : IArtifactType
+    {
+        public string Identifier {get; }
+
+        public MyArtifactType(string identifier)
+        {
+            Identifier = identifier;
+        }
+    }
+}

--- a/Specifications/Applications/for_ApplicationArtifactIdentifier/given/different_artifacts.cs
+++ b/Specifications/Applications/for_ApplicationArtifactIdentifier/given/different_artifacts.cs
@@ -15,18 +15,24 @@ namespace Dolittle.Applications.Specs.for_ApplicationArtifactIdentifier.given
 
         Establish context = () =>
         {
-            var application = new Mock<IApplication>();
-            application.SetupGet(a => a.Name).Returns("SomeApplication");
+            var application = Application.WithName("ApplicationName")
+                .WithStructureStartingWith<BoundedContext>(bc => bc.Required)
+                .Build();
 
-            var location = Mock.Of<IApplicationLocation>(_ => _.Equals(
-                Moq.It.IsAny<IApplicationLocation>()) == true
-                );
-            var artifactA = Mock.Of<IArtifact>();
+            var boundedContext = new BoundedContext("BoundedContext");
+            var location = new ApplicationLocation(new IApplicationLocationSegment[] 
+            {
+                boundedContext
+            });
 
-            var artifactB = Mock.Of<IArtifact>();
+            var artifactType = new MyArtifactType("ArtifactType");
 
-            identifier_a = new ApplicationArtifactIdentifier(application.Object, location, artifactA);
-            identifier_b = new ApplicationArtifactIdentifier(application.Object, location, artifactB);
+            var artifactA = new Artifact("ArtifactA", artifactType, 1);
+
+            var artifactB = new Artifact("ArtifactB", artifactType, 1);
+
+            identifier_a = new ApplicationArtifactIdentifier(application, location, artifactA);
+            identifier_b = new ApplicationArtifactIdentifier(application, location, artifactB);
         };
     }
 }

--- a/Specifications/Applications/for_ApplicationArtifactIdentifier/given/identifiers_with_different_applications.cs
+++ b/Specifications/Applications/for_ApplicationArtifactIdentifier/given/identifiers_with_different_applications.cs
@@ -15,19 +15,26 @@ namespace Dolittle.Applications.Specs.for_ApplicationArtifactIdentifier.given
 
         Establish context = () =>
         {
-            var application_a = new Mock<IApplication>();
-            application_a.SetupGet(a => a.Name).Returns("ApplicationA");
-
-            var application_b = new Mock<IApplication>();
-            application_b.SetupGet(a => a.Name).Returns("ApplicationB");
-
-            var location = Mock.Of<IApplicationLocation>(_ => _.Equals(
-                Moq.It.IsAny<IApplicationLocation>()) == true
-                );
+            var applicationA = Application.WithName("ApplicationNameA")
+                .WithStructureStartingWith<BoundedContext>(bc => bc.Required)
+                .Build();
             
-            var artifact = Mock.Of<IArtifact>();
-            identifier_a = new ApplicationArtifactIdentifier(application_a.Object, location, artifact);
-            identifier_b = new ApplicationArtifactIdentifier(application_b.Object, location, artifact);
+            var applicationB = Application.WithName("ApplicationNameB")
+                .WithStructureStartingWith<BoundedContext>(bc => bc.Required)
+                .Build();
+
+            var boundedContext = new BoundedContext("BoundedContext");
+            var location = new ApplicationLocation(new IApplicationLocationSegment[] 
+            {
+                boundedContext
+            });
+
+            var artifactType = new MyArtifactType("ArtifactType");
+
+            var artifact = new Artifact("Artifact", artifactType, 1);
+
+            identifier_a = new ApplicationArtifactIdentifier(applicationA, location, artifact);
+            identifier_b = new ApplicationArtifactIdentifier(applicationB, location, artifact);
         };
        
     }

--- a/Specifications/Applications/for_ApplicationArtifactIdentifier/given/identifiers_with_different_locations.cs
+++ b/Specifications/Applications/for_ApplicationArtifactIdentifier/given/identifiers_with_different_locations.cs
@@ -15,15 +15,28 @@ namespace Dolittle.Applications.Specs.for_ApplicationArtifactIdentifier.given
 
         Establish context = () =>
         {
-            var application = new Mock<IApplication>();
-            application.SetupGet(a => a.Name).Returns("SomeApplication");
-            var location_a = Mock.Of<IApplicationLocation>();
-            var location_b = Mock.Of<IApplicationLocation>();
+            var application = Application.WithName("ApplicationName")
+                .WithStructureStartingWith<BoundedContext>(bc => bc.Required)
+                .Build();
+            
+            var boundedContext = new BoundedContext("BoundedContext");
+            var locationA = new ApplicationLocation(new IApplicationLocationSegment[] 
+            {
+                boundedContext
+            });
 
-            var artifact = Mock.Of<IArtifact>();
+            var boundedContextB = new BoundedContext("BoundedContextB");
+            var locationB = new ApplicationLocation(new IApplicationLocationSegment[] 
+            {
+                boundedContextB
+            });
 
-            identifier_a = new ApplicationArtifactIdentifier(application.Object, location_a, artifact);
-            identifier_b = new ApplicationArtifactIdentifier(application.Object, location_b, artifact);
+            var artifactType = new MyArtifactType("ArtifactType");
+
+            var artifact = new Artifact("Artifact", artifactType, 1);
+
+            identifier_a = new ApplicationArtifactIdentifier(application, locationA, artifact);
+            identifier_b = new ApplicationArtifactIdentifier(application, locationB, artifact);
         };
     }
 }

--- a/Specifications/Applications/for_ApplicationArtifactIdentifier/given/same_artifacts.cs
+++ b/Specifications/Applications/for_ApplicationArtifactIdentifier/given/same_artifacts.cs
@@ -15,15 +15,22 @@ namespace Dolittle.Applications.Specs.for_ApplicationArtifactIdentifier.given
 
         Establish context = () =>
         {
-            var application = new Mock<IApplication>();
-            application.SetupGet(a => a.Name).Returns("SomeApplication");
-            var location = new Mock<IApplicationLocation>();
-            location.Setup(_ => _.Equals(Moq.It.IsAny<IApplicationLocation>())).Returns(true);
-            
-            var artifact = Mock.Of<IArtifact>();
+            var application = Application.WithName("ApplicationName")
+                .WithStructureStartingWith<BoundedContext>(bc => bc.Required)
+                .Build();
 
-            identifier_a = new ApplicationArtifactIdentifier(application.Object, location.Object, artifact);
-            identifier_b = new ApplicationArtifactIdentifier(application.Object, location.Object, artifact);
+            var boundedContext = new BoundedContext("BoundedContext");
+            var location = new ApplicationLocation(new IApplicationLocationSegment[] 
+            {
+                boundedContext
+            });
+
+            var artifactType = new MyArtifactType("ArtifactType");
+
+            var artifact = new Artifact("Artifact", artifactType, 1);
+
+            identifier_a = new ApplicationArtifactIdentifier(application, location, artifact);
+            identifier_b = new ApplicationArtifactIdentifier(application, location, artifact);
         };
     }
 }


### PR DESCRIPTION
There was a bug when we did comparison of two IApplicationLocation properties that were essentially the same in two different object of IArtifactIdentifier. 

When doing == or != with IApplicationLocations it apparently gave the wrong result (even tough the operators were overloaded in the only concrete class of IApplicationLocation).

- Changed Equals to use the property's Equals method instead of the equality operators.
- Changed ApplicationLocation Equals to do Equality check on each segment instead of getting the HashCodes 