### PR TITLE
Claims need to implement equality

### DIFF
--- a/Source/Security/Claims.cs
+++ b/Source/Security/Claims.cs
@@ -19,7 +19,7 @@ namespace Dolittle.Security
     /// <summary>
     /// Represents a set of <see cref="Claim">Claims</see>
     /// </summary>
-    public class Claims : IEnumerable<Claim>
+    public class Claims : IEnumerable<Claim>, IEquatable<Claims>
     {  
         private List<Claim> _claims = new List<Claim>();
 
@@ -30,6 +30,89 @@ namespace Dolittle.Security
         public Claims(IEnumerable<Claim> claims)
         {
             _claims.AddRange(claims ?? Enumerable.Empty<Claim>());
+        }
+
+        /// <summary>
+        /// Determines if two Claims objects are equal
+        /// True if it contains the same claims ( in any order )
+        /// </summary>
+        /// <param name="other">The other <see cref="Claims" /> object to compare to</param>
+        /// <returns>True if equal, False otherwise</returns>
+        public bool Equals(Claims other)
+        {
+            if(other == null || other.Count() != this.Count())
+                return false;
+
+            var thisClaims = _claims.OrderBy(_ => _.Name).ThenBy(_ => _.ValueType).ThenBy(_ => _.Value).ToArray();
+            var otherClaims = other.OrderBy(_ => _.Name).ThenBy(_ => _.ValueType).ThenBy(_ => _.Value).ToArray();
+
+            for (int i = 0; i < thisClaims.Count(); i++)
+            {
+                if (!object.Equals(thisClaims[i], otherClaims[i]))
+                {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        /// <summary>
+        /// Determines if two Claims objects are equal
+        /// True if it contains the same claims ( in any order )
+        /// </summary>
+        /// <param name="other">The other object to compare to</param>
+        /// <returns>True if equal, False otherwise</returns>
+        public override bool Equals(object other)
+        {
+            return Equals(other as Claims);
+        }
+
+        /// <summary>
+        /// Gets a HashCode representing the value of all the claims
+        /// </summary>
+        /// <returns>The hashcode</returns>
+        public override int GetHashCode()
+        {
+            var array = _claims.OrderBy(_ => _.Name).ThenBy(_ => _.ValueType).ThenBy(_ => _.Value).ToArray();
+            unchecked
+            {
+                int hash = 17;
+
+                // get hash code for all items in array
+                foreach (var item in array)
+                {
+                    hash = hash * 23 + ((item != null) ? item.GetHashCode() : 0);
+                }
+
+                return hash;
+            }
+        }
+
+
+        /// <summary>
+        /// Uses the same equality as the Equals method
+        /// </summary>
+        /// <param name="first">First Claim</param>
+        /// <param name="second">Second Claim</param>
+        /// <returns>True if equals, false otherwise</returns>
+        public static bool operator == (Claims first, Claims second) 
+        {
+            if(Object.Equals(first,null) && Object.Equals(second,null))
+                return true;
+            if(Object.Equals(first,null))
+                return false;
+            return first.Equals(second);
+        }
+
+        /// <summary>
+        /// Uses the same equality as the Equals method
+        /// </summary>
+        /// <param name="first">First Claim</param>
+        /// <param name="second">Second Claim</param>
+        /// <returns>True if not equals, false otherwise</returns>
+        public static bool operator != (Claims first, Claims second) 
+        {
+            return !(first == second);
         }
 
         /// <summary>

--- a/Specifications/Concepts/for_ConceptAs/when_checking_is_greater_than.cs
+++ b/Specifications/Concepts/for_ConceptAs/when_checking_is_greater_than.cs
@@ -4,6 +4,7 @@ using Dolittle.Specs.Concepts.given;
 
 namespace Dolittle.Specs.Concepts.for_ConceptAs
 {
+    #pragma warning disable 1718
     [Subject(typeof(ConceptAs<>))]
     public class when_checking_is_greater_than : given.test_concepts
     {
@@ -20,7 +21,6 @@ namespace Dolittle.Specs.Concepts.for_ConceptAs
         static bool most_is_greater_than_self;
         static bool most_is_greater_than_primitive_value;
 
-        static bool blah;
         Because of = () =>
         {
             least_is_greater_than_most = least > most;
@@ -50,4 +50,5 @@ namespace Dolittle.Specs.Concepts.for_ConceptAs
         It determines_most_is_not_greater_than_self = () =>  most_is_greater_than_self.ShouldBeFalse(); 
         It determines_most_is_not_greater_than_primitive_value = () =>  most_is_greater_than_primitive_value.ShouldBeFalse();
     }
+    #pragma warning restore 1718
 }

--- a/Specifications/Concepts/for_ConceptAs/when_checking_is_greater_than_or_equal_to.cs
+++ b/Specifications/Concepts/for_ConceptAs/when_checking_is_greater_than_or_equal_to.cs
@@ -4,6 +4,7 @@ using Dolittle.Specs.Concepts.given;
 
 namespace Dolittle.Specs.Concepts.for_ConceptAs
 {
+    #pragma warning disable 1718
     [Subject(typeof(ConceptAs<>))]
     public class when_checking_is_greater_than_or_equal_to : given.test_concepts
     {
@@ -20,7 +21,6 @@ namespace Dolittle.Specs.Concepts.for_ConceptAs
         static bool most_is_greater_than_or_equal_to_self;
         static bool most_is_greater_than_or_equal_to_primitive_value;
 
-        static bool blah;
         Because of = () =>
         {
             least_is_greater_than_or_equal_to_most = least >= most;
@@ -50,4 +50,5 @@ namespace Dolittle.Specs.Concepts.for_ConceptAs
         It determines_most_is_not_greater_than_or_equal_to_self = () =>  most_is_greater_than_or_equal_to_self.ShouldBeTrue(); 
         It determines_most_is_not_greater_than_or_equal_to_primitive_value = () =>  most_is_greater_than_or_equal_to_primitive_value.ShouldBeTrue();
     }
+    #pragma warning restore 1718
 }

--- a/Specifications/Concepts/for_ConceptAs/when_checking_is_lesser_than.cs
+++ b/Specifications/Concepts/for_ConceptAs/when_checking_is_lesser_than.cs
@@ -4,6 +4,7 @@ using Dolittle.Specs.Concepts.given;
 
 namespace Dolittle.Specs.Concepts.for_ConceptAs
 {
+    #pragma warning disable 1718
     [Subject(typeof(ConceptAs<>))]
     public class when_checking_is_lesser_than : given.test_concepts
     {
@@ -20,7 +21,6 @@ namespace Dolittle.Specs.Concepts.for_ConceptAs
         static bool most_is_lesser_than_self;
         static bool most_is_lesser_than_primitive_value;
 
-        static bool blah;
         Because of = () =>
         {
             least_is_lesser_than_most = least < most;
@@ -50,4 +50,5 @@ namespace Dolittle.Specs.Concepts.for_ConceptAs
         It determines_most_is_not_lesser_than_self = () =>  most_is_lesser_than_self.ShouldBeFalse(); 
         It determines_most_is_not_lesser_than_primitive_value = () =>  most_is_lesser_than_primitive_value.ShouldBeFalse();
     }
+    #pragma warning restore 1718
 }

--- a/Specifications/Concepts/for_ConceptAs/when_checking_is_lesser_than_or_equal_to.cs
+++ b/Specifications/Concepts/for_ConceptAs/when_checking_is_lesser_than_or_equal_to.cs
@@ -4,6 +4,7 @@ using Dolittle.Specs.Concepts.given;
 
 namespace Dolittle.Specs.Concepts.for_ConceptAs
 {
+    #pragma warning disable 1718
     [Subject(typeof(ConceptAs<>))]
     public class when_checking_is_lesser_than_or_equal_to : given.test_concepts
     {
@@ -20,7 +21,6 @@ namespace Dolittle.Specs.Concepts.for_ConceptAs
         static bool most_is_lesser_than_or_equal_to_self;
         static bool most_is_lesser_than_or_equal_to_primitive_value;
 
-        static bool blah;
         Because of = () =>
         {
             least_is_lesser_than_or_equal_to_most = least <= most;
@@ -50,4 +50,5 @@ namespace Dolittle.Specs.Concepts.for_ConceptAs
         It determines_most_is_not_lesser_than_or_equal_to_self = () =>  most_is_lesser_than_or_equal_to_self.ShouldBeTrue(); 
         It determines_most_is_not_lesser_than_or_equal_to_primitive_value = () =>  most_is_lesser_than_or_equal_to_primitive_value.ShouldBeTrue();
     }
+    #pragma warning restore 1718
 }

--- a/Specifications/Security/for_Claims/when_equating_and_getting_hashcode/two_claims_with_different_claims.cs
+++ b/Specifications/Security/for_Claims/when_equating_and_getting_hashcode/two_claims_with_different_claims.cs
@@ -1,0 +1,43 @@
+namespace Security.for_Claims.when_equating_and_getting_hashcode
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using Dolittle.Security;
+    using Machine.Specifications;
+
+    [Subject(typeof(Claims), nameof(Equals))]
+    public class two_claims_with_different_claims
+    {
+        static Claims first;
+        static Claims second; 
+
+        static bool is_equal_by_method;
+        static bool is_equal_by_operator;
+        static bool is_not_equal_by_operator;
+        static bool hash_code_is_equal;
+        Establish context = () => 
+        {
+            var list_one = new List<Claim>();
+            list_one.Add(new Claim("4","4","4"));
+            list_one.Add(new Claim("1","1","1"));
+            var list_two = new List<Claim>();
+            list_two.Add(new Claim("2","2","2"));
+            list_two.Add(new Claim("3","3","3"));
+            first = new Claims(list_one.ToArray());
+            second = new Claims(list_two.ToArray());
+        };
+
+        Because of = () => 
+        {
+            is_equal_by_method = first.Equals(second);
+            is_equal_by_operator = first == second;
+            is_not_equal_by_operator = first != second;
+            hash_code_is_equal = first.GetHashCode() == second.GetHashCode();
+        };
+
+        It should_not_be_equal_when_using_the_Equals_method = () => is_equal_by_method.ShouldBeFalse();
+        It should_not_be_equal_when_using_the_equals_operator = () => is_equal_by_operator.ShouldBeFalse();
+        It should_not_be_equal_when_using_the_not_equals_operator = () => is_not_equal_by_operator.ShouldBeTrue();
+        It should_not_have_the_same_hashcode = () => hash_code_is_equal.ShouldBeFalse();
+    }       
+}

--- a/Specifications/Security/for_Claims/when_equating_and_getting_hashcode/two_claims_with_different_number_of_claims.cs
+++ b/Specifications/Security/for_Claims/when_equating_and_getting_hashcode/two_claims_with_different_number_of_claims.cs
@@ -1,0 +1,42 @@
+namespace Security.for_Claims.when_equating_and_getting_hashcode
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using Dolittle.Security;
+    using Machine.Specifications;
+
+    [Subject(typeof(Claims), nameof(Equals))]
+    public class two_claims_with_different_number_of_claims
+    {
+        static Claims first;
+        static Claims second; 
+
+        static bool is_equal_by_method;
+        static bool is_equal_by_operator;
+        static bool is_not_equal_by_operator;
+        static bool hash_code_is_equal;
+        Establish context = () => 
+        {
+            var list = new List<Claim>();
+            list.Add(new Claim("4","4","4"));
+            list.Add(new Claim("1","1","1"));
+            list.Add(new Claim("2","2","2"));
+            list.Add(new Claim("3","3","3"));
+            first = new Claims(list.ToArray());
+            second = new Claims(list.Take(2).ToArray());
+        };
+
+        Because of = () => 
+        {
+            is_equal_by_method = first.Equals(second);
+            is_equal_by_operator = first == second;
+            is_not_equal_by_operator = first != second;
+            hash_code_is_equal = first.GetHashCode() == second.GetHashCode();
+        };
+
+        It should_not_be_equal_when_using_the_Equals_method = () => is_equal_by_method.ShouldBeFalse();
+        It should_not_be_equal_when_using_the_equals_operator = () => is_equal_by_operator.ShouldBeFalse();
+        It should_not_be_equal_when_using_the_not_equals_operator = () => is_not_equal_by_operator.ShouldBeTrue();
+        It should_not_have_the_same_hashcode = () => hash_code_is_equal.ShouldBeFalse();
+    }  
+}

--- a/Specifications/Security/for_Claims/when_equating_and_getting_hashcode/two_claims_with_identical_claims_in_different_order.cs
+++ b/Specifications/Security/for_Claims/when_equating_and_getting_hashcode/two_claims_with_identical_claims_in_different_order.cs
@@ -1,0 +1,43 @@
+namespace Security.for_Claims.when_equating_and_getting_hashcode
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using Dolittle.Security;
+    using Machine.Specifications;
+
+    [Subject(typeof(Claims), nameof(Equals))]
+    public class two_claims_with_identical_claims_in_different_order
+    {
+        static Claims first;
+        static Claims second; 
+
+        static bool is_equal_by_method;
+        static bool is_equal_by_operator;
+        static bool is_not_equal_by_operator;
+        static bool hash_code_is_equal;
+
+        Establish context = () => 
+        {
+            var list = new List<Claim>();
+            list.Add(new Claim("4","4","4"));
+            list.Add(new Claim("1","1","1"));
+            list.Add(new Claim("2","2","2"));
+            list.Add(new Claim("3","3","3"));
+            first = new Claims(list.ToArray());
+            second = new Claims(list.OrderBy(_ => _.Name).ToArray());
+        };
+
+        Because of = () => 
+        {
+            is_equal_by_method = first.Equals(second);
+            is_equal_by_operator = first == second;
+            is_not_equal_by_operator = first != second;
+            hash_code_is_equal = first.GetHashCode() == second.GetHashCode();
+        };
+
+        It should_be_equal_when_using_the_Equals_method = () => is_equal_by_method.ShouldBeTrue();
+        It should_be_equal_when_using_the_equals_operator = () => is_equal_by_operator.ShouldBeTrue();
+        It should_not_be_not_equal_when_using_the_not_equals_operator = () => is_not_equal_by_operator.ShouldBeFalse();
+        It should_have_the_same_hashcode = () => hash_code_is_equal.ShouldBeTrue();
+    }    
+}

--- a/Specifications/Security/for_Claims/when_equating_and_getting_hashcode/two_claims_with_identical_claims_in_the_same_order.cs
+++ b/Specifications/Security/for_Claims/when_equating_and_getting_hashcode/two_claims_with_identical_claims_in_the_same_order.cs
@@ -1,0 +1,43 @@
+namespace Security.for_Claims.when_equating_and_getting_hashcode
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using Dolittle.Security;
+    using Machine.Specifications;
+
+    [Subject(typeof(Claims), nameof(Equals))]
+    public class two_claims_with_identical_claims_in_the_same_order
+    {
+        static Claims first;
+        static Claims second; 
+
+        static bool is_equal_by_method;
+        static bool is_equal_by_operator;
+        static bool is_not_equal_by_operator;
+        static bool hash_code_is_equal;
+
+        Establish context = () => 
+        {
+            var list = new List<Claim>();
+            list.Add(new Claim("4","4","4"));
+            list.Add(new Claim("1","1","1"));
+            list.Add(new Claim("2","2","2"));
+            list.Add(new Claim("3","3","3"));
+            first = new Claims(list.ToArray());
+            second = new Claims(list.ToArray());
+        };
+
+        Because of = () => 
+        {
+            is_equal_by_method = first.Equals(second);
+            is_equal_by_operator = first == second;
+            is_not_equal_by_operator = first != second;
+            hash_code_is_equal = first.GetHashCode() == second.GetHashCode();
+        };
+
+        It should_be_equal_when_using_the_Equals_method = () => is_equal_by_method.ShouldBeTrue();
+        It should_be_equal_when_using_the_equals_operator = () => is_equal_by_operator.ShouldBeTrue();
+        It should_not_be_not_equal_when_using_the_not_equals_operator = () => is_not_equal_by_operator.ShouldBeFalse();
+        It should_have_the_same_hashcode = () => hash_code_is_equal.ShouldBeTrue();
+    }
+}


### PR DESCRIPTION
Claims are in the event metadata (through the Original Context) so all the equality logic is not broken.

Implement Value Object semantics for Claims.

If the two collections of claims (in any order) are the same, Claims are equal.