### PR TITLE
Need to pass ICanResolvePrincipal into the Securable User extension

### DIFF
--- a/Source/Security/SecurableExtensions.cs
+++ b/Source/Security/SecurableExtensions.cs
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See LICENSE in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 using System;
+using System.Security.Principal;
 
 namespace Dolittle.Security
 {
@@ -15,10 +16,11 @@ namespace Dolittle.Security
         /// Define a user actor for a <see cref="ISecurable">securable</see>
         /// </summary>
         /// <param name="securable"><see cref="ISecurable"/> to secure</param>
+        /// <param name="principalResolver">Resolves the <see cref="IPrincipal" /></param>
         /// <returns>The <see cref="ISecurable"/> chain</returns>
-        public static UserSecurityActor User(this ISecurable securable)
+        public static UserSecurityActor UserFrom(this ISecurable securable, ICanResolvePrincipal principalResolver)
         {
-            var actor = new UserSecurityActor(null);
+            var actor = new UserSecurityActor(principalResolver);
             securable.AddActor(actor);
             return actor;
         }

--- a/Specifications/Security/for_SecurableExtensions/when_specifying_user.cs
+++ b/Specifications/Security/for_SecurableExtensions/when_specifying_user.cs
@@ -11,10 +11,15 @@ namespace Dolittle.Security.Specs.for_SecurableExtensions
     {
         static TypeSecurable securable;
         static ISecurityActor actor;
+        static ICanResolvePrincipal principalResolver;
 
-        Establish context = () => securable = new TypeSecurable(typeof(object));
+        Establish context = () => 
+        {
+            securable = new TypeSecurable(typeof(object));
+            principalResolver = new Mock<ICanResolvePrincipal>().Object;
+        };
 
-        Because of = () => actor = securable.User();
+        Because of = () => actor = securable.UserFrom(principalResolver);
 
         It should_return_an_user_actor_builder = () => actor.ShouldBeOfExactType<UserSecurityActor>();
         It should_add_actor_to_securable = () => securable.Actors.First().ShouldBeOfExactType<UserSecurityActor>();


### PR DESCRIPTION
… or else Security doesn’t work.  This is just to get it up and running.  We need an overhaul.