### PR TITLE
We can now have dolittle projects in paths with spaces

### DIFF
--- a/Source/Assemblies/AssemblyContext.cs
+++ b/Source/Assemblies/AssemblyContext.cs
@@ -29,13 +29,10 @@ namespace Dolittle.Assemblies
         {
             Assembly = assembly;
 
-            AssemblyLoadContext = AssemblyLoadContext.GetLoadContext(assembly);
-            AssemblyLoadContext.Resolving += OnResolving;
-
             DependencyContext = DependencyContext.Load(assembly);
 
             var codeBaseUri = new Uri(assembly.CodeBase);
-            var basePath = Path.GetDirectoryName(codeBaseUri.AbsolutePath);
+            var basePath = Path.GetDirectoryName(codeBaseUri.LocalPath);
 
             _assemblyResolver = new CompositeCompilationAssemblyResolver(new ICompilationAssemblyResolver[]
             {
@@ -44,6 +41,8 @@ namespace Dolittle.Assemblies
                 new PackageCompilationAssemblyResolver(),
                 new PackageRuntimeStoreAssemblyResolver()
             });
+            AssemblyLoadContext = AssemblyLoadContext.GetLoadContext(assembly);
+            AssemblyLoadContext.Resolving += OnResolving;
         }
 
         /// <summary>


### PR DESCRIPTION
Use LocalPath instead of AbsolutePath - local path has path string as "some/path to/dir" opposed to "some/path%20to/dir".

It seems like AppBaseCompilationAssemblyResolver's internal FileSystem wrapper does not recognize paths where spaces are replaced with %20.

This fixes https://github.com/dolittle/DotNET.SDK/issues/180 at least on my mac. Since this reproduces on both mac and Windows I assume that this fix will work independently of platform, or atleast let's hope so.