### PR TITLE
Fix obnoxious logging

### DIFF
--- a/Source/Services.Clients/PingTimedOut.cs
+++ b/Source/Services.Clients/PingTimedOut.cs
@@ -6,7 +6,7 @@ using System;
 namespace Dolittle.Services.Clients
 {
     /// <summary>
-    /// Exception that gets thrown when ping timedout.
+    /// Exception that gets thrown when ping timed out.
     /// </summary>
     public class PingTimedOut : Exception
     {

--- a/Source/Services.Clients/PingTimedOut.cs
+++ b/Source/Services.Clients/PingTimedOut.cs
@@ -14,7 +14,7 @@ namespace Dolittle.Services.Clients
         /// Initializes a new instance of the <see cref="PingTimedOut"/> class.
         /// </summary>
         public PingTimedOut()
-            : base("Ping timedout")
+            : base("Ping timed out")
         {
         }
     }

--- a/Source/Services.Clients/PingTimedOut.cs
+++ b/Source/Services.Clients/PingTimedOut.cs
@@ -1,0 +1,21 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+
+namespace Dolittle.Services.Clients
+{
+    /// <summary>
+    /// Exception that gets thrown when ping timedout.
+    /// </summary>
+    public class PingTimedOut : Exception
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PingTimedOut"/> class.
+        /// </summary>
+        public PingTimedOut()
+            : base("Ping timedout")
+        {
+        }
+    }
+}

--- a/Source/Services.Clients/ReverseCallClient.cs
+++ b/Source/Services.Clients/ReverseCallClient.cs
@@ -197,11 +197,11 @@ namespace Dolittle.Services.Clients
             {
                 if (cancellationToken.IsCancellationRequested)
                 {
-                    _logger.Debug("Reverse call was client cancelled by client");
+                    _logger.Debug("Reverse call was cancelled by client");
                 }
                 else
                 {
-                    _logger.Debug("Reverse call was client cancelled by server");
+                    _logger.Debug("Reverse call was cancelled by server");
                 }
             }
             catch (Exception)

--- a/Source/Services.Clients/ReverseCallClient.cs
+++ b/Source/Services.Clients/ReverseCallClient.cs
@@ -193,6 +193,17 @@ namespace Dolittle.Services.Clients
                     linkedCts.CancelAfter(_pingInterval.Multiply(3));
                 }
             }
+            catch (RpcException ex) when (ex.StatusCode == StatusCode.Cancelled)
+            {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    _logger.Debug("Reverse call was client cancelled by client");
+                }
+                else
+                {
+                    _logger.Debug("Reverse call was client cancelled by server");
+                }
+            }
             catch (Exception)
             {
                 if (linkedCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)

--- a/Source/Services/ReverseCallDispatcher.cs
+++ b/Source/Services/ReverseCallDispatcher.cs
@@ -263,26 +263,36 @@ namespace Dolittle.Services
 
         async Task StartPinging(CancellationToken cancellationToken)
         {
-            while (!cancellationToken.IsCancellationRequested)
+            try
             {
-                await Task.Delay(_pingInterval).ConfigureAwait(false);
-                if (cancellationToken.IsCancellationRequested)
+                while (!cancellationToken.IsCancellationRequested)
                 {
-                    _logger.Debug("Cancellation is requested. Stopping pinging");
-                    return;
-                }
+                    await Task.Delay(_pingInterval).ConfigureAwait(false);
+                    if (cancellationToken.IsCancellationRequested)
+                    {
+                        _logger.Debug("Stopping pinging");
+                        return;
+                    }
 
-                await _writeSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
-                try
-                {
-                    var message = new TServerMessage();
-                    _setPing(message, new Ping());
-                    _logger.Trace("Writing ping");
-                    await _serverStream.WriteAsync(message).ConfigureAwait(false);
+                    await _writeSemaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+                    try
+                    {
+                        var message = new TServerMessage();
+                        _setPing(message, new Ping());
+                        _logger.Trace("Writing ping");
+                        await _serverStream.WriteAsync(message).ConfigureAwait(false);
+                    }
+                    finally
+                    {
+                        _writeSemaphore.Release();
+                    }
                 }
-                finally
+            }
+            catch (Exception ex)
+            {
+                if (!cancellationToken.IsCancellationRequested)
                 {
-                    _writeSemaphore.Release();
+                    _logger.Warning(ex, "An error occurred while pinging");
                 }
             }
         }
@@ -333,7 +343,10 @@ namespace Dolittle.Services
             }
             catch (Exception ex)
             {
-                _logger.Error(ex, "Exception during handling of client messages");
+                if (!cancellationToken.IsCancellationRequested)
+                {
+                    _logger.Warning(ex, "An error occurred during handling of client messages");
+                }
             }
             finally
             {

--- a/Source/Services/ReverseCallDispatcher.cs
+++ b/Source/Services/ReverseCallDispatcher.cs
@@ -268,7 +268,7 @@ namespace Dolittle.Services
                 await Task.Delay(_pingInterval).ConfigureAwait(false);
                 if (cancellationToken.IsCancellationRequested)
                 {
-                    _logger.Warning("Cancellation is requested. Stopping pinging");
+                    _logger.Debug("Cancellation is requested. Stopping pinging");
                     return;
                 }
 
@@ -338,7 +338,7 @@ namespace Dolittle.Services
             finally
             {
                 _completed = true;
-                if (jointCts.IsCancellationRequested)
+                if (jointCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
                 {
                     _logger.Warning("Ping timedout");
                 }

--- a/Source/Services/ReverseCallDispatcher.cs
+++ b/Source/Services/ReverseCallDispatcher.cs
@@ -340,7 +340,7 @@ namespace Dolittle.Services
                 _completed = true;
                 if (jointCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
                 {
-                    _logger.Warning("Ping timedout");
+                    _logger.Debug("Ping timedout");
                 }
 
                 foreach ((_, var completionSource) in _calls)

--- a/Source/Services/ReverseCallDispatcher.cs
+++ b/Source/Services/ReverseCallDispatcher.cs
@@ -353,7 +353,7 @@ namespace Dolittle.Services
                 _completed = true;
                 if (jointCts.IsCancellationRequested && !cancellationToken.IsCancellationRequested)
                 {
-                    _logger.Debug("Ping timedout");
+                    _logger.Debug("Ping timed out");
                 }
 
                 foreach ((_, var completionSource) in _calls)


### PR DESCRIPTION
Added:
* PingTimedOut exception

Changed:
* Overall improvements on log messages
* Try-catch around ReverseCallClient.Connect for logging when rpc was cancelled
* Try-catch around ReverseCallClient.Handle catching RpcException when StatusCode == StatusCode.Cancelled. Log that it was cancelled by either client or server. If neither it was caused by a ping timeout and should throw appropriate PingTimedOut-exception.
* HandleRequest => OnReceivedRequest
* Try-catch around OnReceivedRequest for logging when exceptions occur so that they are not swallowed
* Try-catch around StartPinging in ReverseCallDispatcher for logging when exceptions occur so that they are not swallowed
* Only log warning when exception occurs during handling of client messages and cancellation token is not cancelled
* Ping Timeout Debug log 