### PR TITLE
Add Logging scope

### DIFF
--- a/Source/Logging.Microsoft/LogMessageWriter.cs
+++ b/Source/Logging.Microsoft/LogMessageWriter.cs
@@ -25,6 +25,10 @@ namespace Dolittle.Logging.Microsoft
         }
 
         /// <inheritdoc/>
+        public IDisposable BeginScope(string messageFormat, params object[] args)
+            => _logger.BeginScope(messageFormat, args);
+
+        /// <inheritdoc/>
         public void Write(LogLevel logLevel, string message, params object[] args)
             => _logger.Log(TranslateLogLevel(logLevel), message, args);
 

--- a/Source/Logging/Booting/BootLogMessageWriter.cs
+++ b/Source/Logging/Booting/BootLogMessageWriter.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Reactive.Disposables;
 
 namespace Dolittle.Logging.Booting
 {
@@ -23,6 +24,10 @@ namespace Dolittle.Logging.Booting
             _creator = creator;
             _type = type;
         }
+
+        /// <inheritdoc/>
+        public IDisposable BeginScope(string messageFormat, params object[] args)
+            => Disposable.Empty;
 
         /// <inheritdoc/>
         public void Write(LogLevel logLevel, string message, params object[] args)

--- a/Source/Logging/ILogMessageWriter.cs
+++ b/Source/Logging/ILogMessageWriter.cs
@@ -26,5 +26,13 @@ namespace Dolittle.Logging
         /// <param name="message">Format string of the log message in message template format.</param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
         void Write(LogLevel logLevel, Exception exception, string message, params object[] args);
+
+        /// <summary>
+        /// Formats the message and creates a scope.
+        /// </summary>
+        /// <param name="messageFormat">The <see cref="string" >format string</see>of the log message in message template format.</param>
+        /// <param name="args">The object array that contains zero or more objects to format.</param>
+        /// <returns>A disposable scope object. Can be null.</returns>
+        IDisposable BeginScope(string messageFormat, params object[] args);
     }
 }

--- a/Source/Logging/ILogger.cs
+++ b/Source/Logging/ILogger.cs
@@ -99,5 +99,13 @@ namespace Dolittle.Logging
         /// <param name="message">Format string of the log message in message template format.</param>
         /// <param name="args">An object array that contains zero or more objects to format.</param>
         void Error(Exception exception, string message, params object[] args);
+
+        /// <summary>
+        /// Formats the message and creates a scope.
+        /// </summary>
+        /// <param name="messageFormat">The <see cref="string" >format string</see>of the log message in message template format.</param>
+        /// <param name="args">The object array that contains zero or more objects to format.</param>
+        /// <returns>A disposable scope object. Can be null.</returns>
+        IDisposable BeginScope(string messageFormat, params object[] args);
     }
 }

--- a/Source/Logging/Internal/InternalLogger.cs
+++ b/Source/Logging/Internal/InternalLogger.cs
@@ -2,6 +2,8 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Linq;
+using System.Reactive.Disposables;
 
 namespace Dolittle.Logging.Internal
 {
@@ -59,6 +61,10 @@ namespace Dolittle.Logging.Internal
 
         /// <inheritdoc/>
         public void Error(Exception exception, string message, params object[] args) => Write(LogLevel.Error, exception, message, args);
+
+        /// <inheritdoc/>
+        public IDisposable BeginScope(string messageFormat, params object[] args)
+            => new CompositeDisposable(LogMessageWriters.Select(_ => _.BeginScope(messageFormat, args)).Where(_ => _ != default).ToArray());
 
         /// <summary>
         /// Writes the log message to the log message writers in <see cref="LogMessageWriters"/>.

--- a/Source/Logging/Internal/NullLogger.cs
+++ b/Source/Logging/Internal/NullLogger.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System;
+using System.Reactive.Disposables;
 
 namespace Dolittle.Logging.Internal
 {
@@ -81,5 +82,8 @@ namespace Dolittle.Logging.Internal
         public void Error(Exception exception, string message, params object[] args)
         {
         }
+
+        /// <inheritdoc/>
+        public IDisposable BeginScope(string messageFormat, params object[] args) => Disposable.Empty;
     }
 }

--- a/Source/Logging/Logging.csproj
+++ b/Source/Logging/Logging.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="System.Reactive" Version="4.4.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Specifications/Logging/for_InternalLogger/when_beginning_scope.cs
+++ b/Specifications/Logging/for_InternalLogger/when_beginning_scope.cs
@@ -1,0 +1,46 @@
+// Copyright (c) Dolittle. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System;
+using System.Reactive.Disposables;
+using Machine.Specifications;
+
+namespace Dolittle.Specs.Logging.for_InternalLogger
+{
+    public class when_beginning_scope : given.a_logger_with_two_writers
+    {
+        static string message;
+        static object[] arguments;
+        static IDisposable result;
+
+        Establish context = () =>
+        {
+            message = "Some message";
+            arguments = new object[] { "some arguments", 1 };
+            writer_one
+                .Setup(_ => _.BeginScope(Moq.It.IsAny<string>(), Moq.It.IsAny<object[]>()))
+                .Returns(Disposable.Empty);
+            writer_two
+                .Setup(_ => _.BeginScope(Moq.It.IsAny<string>(), Moq.It.IsAny<object[]>()))
+                .Returns(Disposable.Empty);
+        };
+
+        Because of = () => result = logger.BeginScope(message, arguments);
+
+        It should_begin_scope_in_writer_one = () =>
+        {
+            writer_one.Verify(_ => _.BeginScope(message, arguments), Moq.Times.Once());
+            writer_one.VerifyNoOtherCalls();
+        };
+
+        It should_forward_to_writer_two_with_level_debug_without_exception = () =>
+        {
+            writer_two.Verify(_ => _.BeginScope(message, arguments), Moq.Times.Once());
+            writer_two.VerifyNoOtherCalls();
+        };
+
+        It should_return_a_dispoable = () => result.ShouldNotBeNull();
+
+        Cleanup cleanup = () => result.Dispose();
+    }
+}


### PR DESCRIPTION
I think that it may be useful for us to have the ability to log in scopes [Microsoft Logger logging scope](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/logging/?view=aspnetcore-3.1#log-scopes).

I used `Disposable.Empty` and `CompositeDisposable` from the [System.Reactive package](https://docs.microsoft.com/en-us/previous-versions/dotnet/reactive-extensions/hh229090%28v%3dvs.103%29). These seems to only be something that is not strictly for ReactiveX,  but actually something that should be added to System.Disposable... The alternative was to create something for ourselves, as `Disposable.Empty` and `CompositeDisposable` is really easy to implement, but lets not recreate the wheel... It's fine if we don't want to use it (and I'm also maybe leaning a bit towards creating our own implementations)